### PR TITLE
Added empty AbstractActionDispatcher::configureOptions implementation

### DIFF
--- a/src/lib/Form/ActionDispatcher/AbstractActionDispatcher.php
+++ b/src/lib/Form/ActionDispatcher/AbstractActionDispatcher.php
@@ -58,7 +58,9 @@ abstract class AbstractActionDispatcher implements ActionDispatcherInterface
      *
      * @param \Symfony\Component\OptionsResolver\OptionsResolver $resolver
      */
-    abstract protected function configureOptions(OptionsResolver $resolver);
+    protected function configureOptions(OptionsResolver $resolver)
+    {
+    }
 
     /**
      * Returns base for action event name. It will be used as default action event name.

--- a/src/lib/Form/ActionDispatcher/UserDispatcher.php
+++ b/src/lib/Form/ActionDispatcher/UserDispatcher.php
@@ -13,10 +13,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class UserDispatcher extends AbstractActionDispatcher
 {
-    protected function configureOptions(OptionsResolver $resolver)
-    {
-    }
-
     protected function getActionEventBaseName()
     {
         return ContentFormEvents::USER_EDIT;


### PR DESCRIPTION
> JIRA: -

### Description

Added empty `Ibexa\ContentForms\Form\ActionDispatcher\AbstractActionDispatcher::configureOptions` implementation as it seems that this become more often an case e.g. 

* Ibexa\ContentForms\Form\ActionDispatcher\UserDispatcher::configureOptions
* Ibexa\ContentForms\Form\ActionDispatcher\AbstractActionDispatcher in product catalog