### PR TITLE
IBX-1694: Rebranded dependency injection container service tags

### DIFF
--- a/src/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPass.php
+++ b/src/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPass.php
@@ -19,7 +19,6 @@ use Symfony\Component\DependencyInjection\Reference;
 class FieldTypeFormMapperDispatcherPass implements CompilerPassInterface
 {
     public const FIELD_TYPE_FORM_MAPPER_DISPATCHER = 'ezplatform.content_forms.field_type_form_mapper.dispatcher';
-    public const DEPRECATED_FIELD_TYPE_FORM_MAPPER_VALUE_SERVICE_TAG = 'ez.fieldFormMapper.value';
     public const FIELD_TYPE_FORM_MAPPER_VALUE_SERVICE_TAG = 'ezplatform.field_type.form_mapper.value';
 
     public function process(ContainerBuilder $container)
@@ -30,7 +29,10 @@ class FieldTypeFormMapperDispatcherPass implements CompilerPassInterface
 
         $dispatcherDefinition = $container->findDefinition(self::FIELD_TYPE_FORM_MAPPER_DISPATCHER);
 
-        foreach ($this->findTaggedFormMapperServices($container) as $id => $tags) {
+        $taggedServiceIds = $container->findTaggedServiceIds(
+            self::FIELD_TYPE_FORM_MAPPER_VALUE_SERVICE_TAG
+        );
+        foreach ($taggedServiceIds as $id => $tags) {
             foreach ($tags as $tag) {
                 if (!isset($tag['fieldType'])) {
                     throw new LogicException(
@@ -43,38 +45,6 @@ class FieldTypeFormMapperDispatcherPass implements CompilerPassInterface
         }
     }
 
-    /**
-     * Gathers services tagged as either
-     * - ez.fieldFormMapper.value (deprecated)
-     * - ez.fieldFormMapper.definition (deprecated)
-     * - ezplatform.field_type.form_mapper.value
-     * - ezplatform.field_type.form_mapper.definition.
-     *
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     *
-     * @return array
-     */
-    private function findTaggedFormMapperServices(ContainerBuilder $container): array
-    {
-        $deprecatedFieldFormMapperValueTags = $container->findTaggedServiceIds(self::DEPRECATED_FIELD_TYPE_FORM_MAPPER_VALUE_SERVICE_TAG);
-        $fieldFormMapperValueTags = $container->findTaggedServiceIds(self::FIELD_TYPE_FORM_MAPPER_VALUE_SERVICE_TAG);
-
-        foreach ($deprecatedFieldFormMapperValueTags as $ezFieldFormMapperValueTag) {
-            @trigger_error(
-                sprintf(
-                    'The `%s` service tag is deprecated and will be removed in eZ Platform 4.0. Use `%s` instead.',
-                    self::DEPRECATED_FIELD_TYPE_FORM_MAPPER_VALUE_SERVICE_TAG,
-                    self::FIELD_TYPE_FORM_MAPPER_VALUE_SERVICE_TAG
-                ),
-                E_USER_DEPRECATED
-            );
-        }
-
-        return array_merge(
-            $deprecatedFieldFormMapperValueTags,
-            $fieldFormMapperValueTags
-        );
-    }
 }
 
 class_alias(FieldTypeFormMapperDispatcherPass::class, 'EzSystems\EzPlatformContentFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperDispatcherPass');

--- a/src/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPass.php
+++ b/src/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPass.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Reference;
 class FieldTypeFormMapperDispatcherPass implements CompilerPassInterface
 {
     public const FIELD_TYPE_FORM_MAPPER_DISPATCHER = 'ezplatform.content_forms.field_type_form_mapper.dispatcher';
-    public const FIELD_TYPE_FORM_MAPPER_VALUE_SERVICE_TAG = 'ezplatform.field_type.form_mapper.value';
+    public const FIELD_TYPE_FORM_MAPPER_VALUE_SERVICE_TAG = 'ibexa.admin_ui.field_type.form.mapper.value';
 
     public function process(ContainerBuilder $container)
     {
@@ -44,7 +44,6 @@ class FieldTypeFormMapperDispatcherPass implements CompilerPassInterface
             }
         }
     }
-
 }
 
 class_alias(FieldTypeFormMapperDispatcherPass::class, 'EzSystems\EzPlatformContentFormsBundle\DependencyInjection\Compiler\FieldTypeFormMapperDispatcherPass');

--- a/src/bundle/Resources/config/fieldtypes.yaml
+++ b/src/bundle/Resources/config/fieldtypes.yaml
@@ -25,51 +25,51 @@ services:
 
     Ibexa\ContentForms\FieldType\Mapper\AuthorFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezauthor }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezauthor }
 
     Ibexa\ContentForms\FieldType\Mapper\BinaryFileFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezbinaryfile }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezbinaryfile }
 
     Ibexa\ContentForms\FieldType\Mapper\CheckboxFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezboolean }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezboolean }
 
     Ibexa\ContentForms\FieldType\Mapper\SelectionFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezselection }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezselection }
 
     Ibexa\ContentForms\FieldType\Mapper\CountryFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezcountry }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezcountry }
 
     Ibexa\ContentForms\FieldType\Mapper\DateFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezdate }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezdate }
 
     Ibexa\ContentForms\FieldType\Mapper\DateTimeFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezdatetime }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezdatetime }
 
     Ibexa\ContentForms\FieldType\Mapper\FloatFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezfloat }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezfloat }
 
     Ibexa\ContentForms\FieldType\Mapper\ImageFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezimage }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezimage }
 
     Ibexa\ContentForms\FieldType\Mapper\IntegerFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezinteger }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezinteger }
 
     Ibexa\ContentForms\FieldType\Mapper\ISBNFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezisbn }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezisbn }
 
     Ibexa\ContentForms\FieldType\Mapper\MediaFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezmedia }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezmedia }
 
     Ibexa\ContentForms\FieldType\Mapper\AbstractRelationFormMapper:
         abstract: true
@@ -82,7 +82,7 @@ services:
         autoconfigure: false
         public: false
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezobjectrelation }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezobjectrelation }
 
     Ibexa\ContentForms\FieldType\Mapper\RelationListFormMapper:
         parent: Ibexa\ContentForms\FieldType\Mapper\AbstractRelationFormMapper
@@ -90,38 +90,38 @@ services:
         autoconfigure: false
         public: false
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezobjectrelationlist }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezobjectrelationlist }
 
     Ibexa\ContentForms\FieldType\Mapper\TextLineFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezstring }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezstring }
 
     Ibexa\ContentForms\FieldType\Mapper\TextBlockFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: eztext }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: eztext }
 
     Ibexa\ContentForms\FieldType\Mapper\TimeFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: eztime }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: eztime }
 
     Ibexa\ContentForms\FieldType\Mapper\FormTypeBasedFieldValueFormMapper:
         abstract: true
 
     Ibexa\ContentForms\FieldType\Mapper\UserAccountFieldValueFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezuser }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezuser }
 
     Ibexa\ContentForms\FieldType\Mapper\UrlFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezurl }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezurl }
 
     Ibexa\ContentForms\FieldType\Mapper\MapLocationFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezgmaplocation }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezgmaplocation }
 
     Ibexa\ContentForms\FieldType\Mapper\KeywordFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezkeyword }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezkeyword }
 
     ezplatform.content_forms.field_type.form_mapper.ezemail:
         parent: Ibexa\ContentForms\FieldType\Mapper\FormTypeBasedFieldValueFormMapper
@@ -129,10 +129,10 @@ services:
         autoconfigure: false
         public: false
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezemail }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezemail }
         calls:
             - [setFormType, ['Symfony\Component\Form\Extension\Core\Type\EmailType']]
 
     Ibexa\ContentForms\FieldType\Mapper\ImageAssetFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezimageasset }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezimageasset }

--- a/src/bundle/Resources/config/views.yaml
+++ b/src/bundle/Resources/config/views.yaml
@@ -12,13 +12,13 @@ services:
             - '@ezpublish.view.view_parameters.injector.dispatcher'
             - '@ezplatform.content_forms.action_dispatcher.content'
         tags:
-            - { name: ibexa.view_builder }
+            - { name: ibexa.view.builder }
 
     Ibexa\ContentForms\Content\View\Provider\ContentEditView\Configured:
         arguments:
             - '@ezplatform.repository_forms.content_edit_view.matcher_factory'
         tags:
-            - { name: ezpublish.view_provider, type: Ibexa\ContentForms\Content\View\ContentEditView, priority: 10 }
+            - { name: ibexa.view.provider, type: Ibexa\ContentForms\Content\View\ContentEditView, priority: 10 }
 
     ezplatform.repository_forms.content_edit_view.matcher_factory:
         class: '%ezpublish.view.matcher_factory.class%'
@@ -50,13 +50,13 @@ services:
             - '@ezpublish.view.view_parameters.injector.dispatcher'
             - '@ezplatform.content_forms.action_dispatcher.content'
         tags:
-            - { name: ibexa.view_builder }
+            - { name: ibexa.view.builder }
 
     Ibexa\ContentForms\Content\View\Provider\ContentCreateView\Configured:
         arguments:
             - '@ezplatform.repository_forms.content_create_view.matcher_factory'
         tags:
-            - {name: ezpublish.view_provider, type: 'Ibexa\ContentForms\Content\View\ContentCreateView', priority: 10}
+            - {name: ibexa.view.provider, type: 'Ibexa\ContentForms\Content\View\ContentCreateView', priority: 10}
 
     ezplatform.repository_forms.content_create_view.matcher_factory:
         class: '%ezpublish.view.matcher_factory.class%'

--- a/tests/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPassTest.php
@@ -51,7 +51,6 @@ class FieldTypeFormMapperDispatcherPassTest extends AbstractCompilerPassTestCase
     public function tagsProvider(): array
     {
         return [
-            [FieldTypeFormMapperDispatcherPass::DEPRECATED_FIELD_TYPE_FORM_MAPPER_VALUE_SERVICE_TAG],
             [FieldTypeFormMapperDispatcherPass::FIELD_TYPE_FORM_MAPPER_VALUE_SERVICE_TAG],
         ];
     }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1694](https://issues.ibexa.co/browse/IBX-1694)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#12

In this Pull Request we rename Ibexa's dependency injection container service tags according to the map provided by ibexa/compatibility-layer#12 as a part of the rebranding process. Backward compatibility for old service tags is provided by ibexa/compatibility-layer#12.

There was also the `ez.fieldFormMapper.value` tag which was deprecated before Ibexa 3.3 and thus was dropped completely.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Asked for a review
