### PR TITLE
IBX-1696: Rebranded Container parameters and Config Resolver namespaces

### DIFF
--- a/src/bundle/Resources/config/ezpublish_default_settings.yaml
+++ b/src/bundle/Resources/config/ezpublish_default_settings.yaml
@@ -1,10 +1,10 @@
 parameters:
-    ezsettings.default.content_edit.templates.edit: '@@IbexaContentForms/Content/content_edit.html.twig'
-    ezsettings.default.content_edit.templates.create: '@@IbexaContentForms/Content/content_edit.html.twig'
-    ezsettings.default.content_edit.templates.create_draft: '@@IbexaContentForms/Content/content_create_draft.html.twig'
+    ibexa.site_access.config.default.content_edit.templates.edit: '@@IbexaContentForms/Content/content_edit.html.twig'
+    ibexa.site_access.config.default.content_edit.templates.create: '@@IbexaContentForms/Content/content_edit.html.twig'
+    ibexa.site_access.config.default.content_edit.templates.create_draft: '@@IbexaContentForms/Content/content_create_draft.html.twig'
 
-    ezsettings.default.user_edit.templates.update: '@@IbexaContentForms/Content/content_edit.html.twig'
-    ezsettings.default.user_edit.templates.create: '@@IbexaContentForms/Content/content_edit.html.twig'
+    ibexa.site_access.config.default.user_edit.templates.update: '@@IbexaContentForms/Content/content_edit.html.twig'
+    ibexa.site_access.config.default.user_edit.templates.create: '@@IbexaContentForms/Content/content_edit.html.twig'
 
-    ezsettings.default.content_edit_view: {}
-    ezsettings.default.content_create_view: {}
+    ibexa.site_access.config.default.content_edit_view: {}
+    ibexa.site_access.config.default.content_create_view: {}

--- a/src/bundle/Resources/config/fieldtypes.yaml
+++ b/src/bundle/Resources/config/fieldtypes.yaml
@@ -17,7 +17,7 @@ services:
 
     Ibexa\ContentForms\Form\Type\FieldType\CountryFieldType:
         arguments:
-            $countriesInfo: '%ezpublish.fieldType.ezcountry.data%'
+            $countriesInfo: '%ibexa.field_type.country.data%'
 
     #
     # FormMappers

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -5,7 +5,7 @@ imports:
 
 parameters:
 
-    ezplatform.content_forms.user_content_type_identifier: "user"
+    ibexa.content_forms.user_content_type_identifier: "user"
 
 services:
     Ibexa\ContentForms\FieldType\FieldTypeFormMapperDispatcher: ~

--- a/src/lib/FieldType/DataTransformer/MultipleCountryValueTransformer.php
+++ b/src/lib/FieldType/DataTransformer/MultipleCountryValueTransformer.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\DataTransformerInterface;
 class MultipleCountryValueTransformer implements DataTransformerInterface
 {
     /**
-     * @var array Array of countries from ezpublish.fieldType.ezcountry.data
+     * @var array Array of countries from "ibexa.field_type.country.data"
      */
     protected $countriesInfo;
 

--- a/src/lib/FieldType/DataTransformer/SingleCountryValueTransformer.php
+++ b/src/lib/FieldType/DataTransformer/SingleCountryValueTransformer.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 class SingleCountryValueTransformer implements DataTransformerInterface
 {
     /**
-     * @var array Array of countries from ezpublish.fieldType.ezcountry.data
+     * @var array Array of countries from "ibexa.field_type.country.data"
      */
     protected $countriesInfo;
 

--- a/tests/lib/FieldType/DataTransformer/MultipleCountryValueTransformerTest.php
+++ b/tests/lib/FieldType/DataTransformer/MultipleCountryValueTransformerTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 class MultipleCountryValueTransformerTest extends TestCase
 {
     /**
-     * @var array Array of countries from ezpublish.fieldType.ezcountry.data
+     * @var array Array of countries from "ibexa.field_type.country.data"
      */
     protected $countriesInfo = [
         'AF' => ['Name' => 'Afghanistan', 'Alpha2' => 'AF', 'Alpha3' => 'AFG', 'IDC' => '93'],


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1696](https://issues.ibexa.co/browse/IBX-1696)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#31

Rebranded service container parameter names and Ibexa Config Resolver namespaces to follow unified pattern

### TODO

- [ ] Run regressions
- [ ] Test manually
