### PR TITLE
IBX-6315: Added url param publishedContentId

### DIFF
--- a/src/lib/Form/Processor/ContentFormProcessor.php
+++ b/src/lib/Form/Processor/ContentFormProcessor.php
@@ -187,11 +187,13 @@ class ContentFormProcessor implements EventSubscriberInterface
             ? $referrerLocation->id
             : $content->contentInfo->mainLocationId;
 
+        $contentId = $content->id;
         $redirectUrl = $form['redirectUrlAfterPublish']->getData() ?: $this->router->generate(
             'ibexa.content.view',
             [
-                'contentId' => $content->id,
+                'contentId' => $contentId,
                 'locationId' => $locationId,
+                'publishedContentId' => $contentId,
             ]
         );
 


### PR DESCRIPTION
https://issues.ibexa.co/browse/IBX-6315

Related to: https://github.com/ibexa/admin-ui/pull/872

This PR adds `publishedContentId` url param to inform which content have been published. This is needed for communication between open tabs and dynamically updating title of embedded content item. 

**Example:**
First open tab contains form with embedded content item. Second tab contains edit form of embedded content item in first tab. When title for content has been published in second tab, the title of embedded item on first tab should dynamically be updated without refreshing page. 