### PR TITLE
IBX-6856: Added view variable mime types for ezimage field type

### DIFF
--- a/src/lib/Form/Type/FieldType/ImageAssetFieldType.php
+++ b/src/lib/Form/Type/FieldType/ImageAssetFieldType.php
@@ -22,6 +22,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\Mime\MimeTypesInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -36,16 +37,18 @@ class ImageAssetFieldType extends AbstractType
     /** @var \Ibexa\ContentForms\ConfigResolver\MaxUploadSize */
     private $maxUploadSize;
 
-    /**
-     * @param \Ibexa\Contracts\Core\Repository\ContentService $contentService
-     * @param \Ibexa\Core\FieldType\ImageAsset\AssetMapper $mapper
-     * @param \Ibexa\ContentForms\ConfigResolver\MaxUploadSize $maxUploadSize
-     */
-    public function __construct(ContentService $contentService, AssetMapper $mapper, MaxUploadSize $maxUploadSize)
-    {
+    private MimeTypesInterface $mimeTypes;
+
+    public function __construct(
+        ContentService $contentService,
+        AssetMapper $mapper,
+        MaxUploadSize $maxUploadSize,
+        MimeTypesInterface $mimeTypes
+    ) {
         $this->contentService = $contentService;
         $this->maxUploadSize = $maxUploadSize;
         $this->assetMapper = $mapper;
+        $this->mimeTypes = $mimeTypes;
     }
 
     public function getName()
@@ -116,6 +119,7 @@ class ImageAssetFieldType extends AbstractType
 
         if (!empty($mimeTypes)) {
             $view->vars['mime_types'] = $mimeTypes;
+            $view->vars['image_extensions'] = $this->getMimeTypesExtensions($mimeTypes);
         }
 
         $view->vars['max_file_size'] = $this->getMaxFileSize();
@@ -143,6 +147,21 @@ class ImageAssetFieldType extends AbstractType
         }
 
         return (float)$this->maxUploadSize->get();
+    }
+
+    /**
+     * @param array<string> $mimeTypes
+     *
+     * @return array<string, array<string>>
+     */
+    private function getMimeTypesExtensions(array $mimeTypes): array
+    {
+        $extensions = [];
+        foreach ($mimeTypes as $mimeType) {
+            $extensions[$mimeType] = $this->mimeTypes->getExtensions($mimeType);
+        }
+
+        return $extensions;
     }
 }
 

--- a/src/lib/Form/Type/FieldType/ImageAssetFieldType.php
+++ b/src/lib/Form/Type/FieldType/ImageAssetFieldType.php
@@ -110,6 +110,14 @@ class ImageAssetFieldType extends AbstractType
             }
         }
 
+        $mimeTypes = $this->assetMapper
+            ->getAssetFieldDefinition()
+            ->getFieldSettings()['mimeTypes'] ?? [];
+
+        if (!empty($mimeTypes)) {
+            $view->vars['mime_types'] = $mimeTypes;
+        }
+
         $view->vars['max_file_size'] = $this->getMaxFileSize();
     }
 

--- a/src/lib/Form/Type/FieldType/ImageFieldType.php
+++ b/src/lib/Form/Type/FieldType/ImageFieldType.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\Mime\MimeTypesInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -22,6 +23,13 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ImageFieldType extends AbstractType
 {
+    private MimeTypesInterface $mimeTypes;
+
+    public function __construct(MimeTypesInterface $mimeTypes)
+    {
+        $this->mimeTypes = $mimeTypes;
+    }
+
     public function getName()
     {
         return $this->getBlockPrefix();
@@ -59,6 +67,7 @@ class ImageFieldType extends AbstractType
         $view->vars += [
             'is_alternative_text_required' => $options['is_alternative_text_required'],
             'mime_types' => $options['mime_types'],
+            'image_extensions' => $this->getMimeTypesExtensions($options['mime_types']),
         ];
     }
 
@@ -68,10 +77,27 @@ class ImageFieldType extends AbstractType
             'translation_domain' => 'ibexa_content_forms_fieldtype',
             'is_alternative_text_required' => false,
             'mime_types' => [],
+            'image_extensions' => [],
         ]);
 
         $resolver->setAllowedTypes('is_alternative_text_required', 'bool');
         $resolver->setAllowedTypes('mime_types', ['array']);
+        $resolver->setAllowedTypes('image_extensions', ['array']);
+    }
+
+    /**
+     * @param array<string> $mimeTypes
+     *
+     * @return array<string, array<string>>
+     */
+    private function getMimeTypesExtensions(array $mimeTypes): array
+    {
+        $extensions = [];
+        foreach ($mimeTypes as $mimeType) {
+            $extensions[$mimeType] = $this->mimeTypes->getExtensions($mimeType);
+        }
+
+        return $extensions;
     }
 }
 

--- a/src/lib/Form/Type/FieldType/ImageFieldType.php
+++ b/src/lib/Form/Type/FieldType/ImageFieldType.php
@@ -58,6 +58,7 @@ class ImageFieldType extends AbstractType
     {
         $view->vars += [
             'is_alternative_text_required' => $options['is_alternative_text_required'],
+            'mime_types' => $options['mime_types'],
         ];
     }
 
@@ -66,9 +67,11 @@ class ImageFieldType extends AbstractType
         $resolver->setDefaults([
             'translation_domain' => 'ibexa_content_forms_fieldtype',
             'is_alternative_text_required' => false,
+            'mime_types' => [],
         ]);
 
         $resolver->setAllowedTypes('is_alternative_text_required', 'bool');
+        $resolver->setAllowedTypes('mime_types', ['array']);
     }
 }
 


### PR DESCRIPTION
https://issues.ibexa.co/browse/IBX-6856

| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-6856](https://issues.ibexa.co/browse/IBX-6856)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.6` 
| **BC breaks**                          | no
| **Doc needed**                       | no

https://github.com/ibexa/core/pull/300
https://github.com/ibexa/admin-ui/pull/1021
https://github.com/ibexa/image-editor/pull/80

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (`main` for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/php-dev` and/or `@ibexa/javascript-dev`).
