### PR TITLE
IBX-7502: Moved Image asset file validation to field type definition

### DIFF
--- a/src/lib/Form/Type/FieldType/ImageAssetFieldType.php
+++ b/src/lib/Form/Type/FieldType/ImageAssetFieldType.php
@@ -24,7 +24,6 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Mime\MimeTypesInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Validator\Constraints as Assert;
 
 class ImageAssetFieldType extends AbstractType
 {
@@ -79,11 +78,6 @@ class ImageAssetFieldType extends AbstractType
                 [
                     'label' => /** @Desc("File") */ 'content.field_type.binary_base.file',
                     'required' => $options['required'],
-                    'constraints' => [
-                        new Assert\File([
-                            'maxSize' => $this->getMaxFileSize(),
-                        ]),
-                    ],
                     'mapped' => false,
                 ]
             )
@@ -141,12 +135,7 @@ class ImageAssetFieldType extends AbstractType
             ->getAssetFieldDefinition()
             ->getValidatorConfiguration();
 
-        $maxFileSize = $validatorConfiguration['FileSizeValidator']['maxFileSize'];
-        if ($maxFileSize > 0) {
-            return (float)min($maxFileSize * 1024 * 1024, $this->maxUploadSize->get());
-        }
-
-        return (float)$this->maxUploadSize->get();
+        return (float)$validatorConfiguration['FileSizeValidator']['maxFileSize'] * 1024 * 1024;
     }
 
     /**


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | [IBX-7502](https://issues.ibexa.co/browse/IBX-7502) |
| **Type**                 | bug                            |
| **Target Ibexa version** | `v4.6`              |
| **BC breaks**            | no                                              |

Moved file size validation to image asset field type definition: https://github.com/ibexa/core/pull/320

#### Checklist:

- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for
  front-end changes).
