### PR TITLE
IBX-7935: Handled User-related structs in `FieldCollectionType` dispatcher

### DIFF
--- a/src/bundle/Controller/UserController.php
+++ b/src/bundle/Controller/UserController.php
@@ -17,6 +17,7 @@ use Ibexa\ContentForms\Form\Type\User\UserUpdateType;
 use Ibexa\ContentForms\User\View\UserCreateView;
 use Ibexa\ContentForms\User\View\UserUpdateView;
 use Ibexa\Contracts\ContentForms\Content\Form\Provider\GroupedContentFormFieldsProviderInterface;
+use Ibexa\Contracts\Core\Repository\ContentService;
 use Ibexa\Contracts\Core\Repository\ContentTypeService;
 use Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException;
 use Ibexa\Contracts\Core\Repository\LanguageService;
@@ -53,6 +54,9 @@ class UserController extends Controller
     /** @var \Ibexa\Contracts\ContentForms\Content\Form\Provider\GroupedContentFormFieldsProviderInterface */
     private $groupedContentFormFieldsProvider;
 
+    /** @var \Ibexa\Contracts\Core\Repository\ContentService */
+    private $contentService;
+
     public function __construct(
         ContentTypeService $contentTypeService,
         UserService $userService,
@@ -61,7 +65,8 @@ class UserController extends Controller
         ActionDispatcherInterface $userActionDispatcher,
         PermissionResolver $permissionResolver,
         UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider,
-        GroupedContentFormFieldsProviderInterface $groupedContentFormFieldsProvider
+        GroupedContentFormFieldsProviderInterface $groupedContentFormFieldsProvider,
+        ContentService $contentService
     ) {
         $this->contentTypeService = $contentTypeService;
         $this->userService = $userService;
@@ -71,6 +76,7 @@ class UserController extends Controller
         $this->permissionResolver = $permissionResolver;
         $this->userLanguagePreferenceProvider = $userLanguagePreferenceProvider;
         $this->groupedContentFormFieldsProvider = $groupedContentFormFieldsProvider;
+        $this->contentService = $contentService;
     }
 
     /**
@@ -114,6 +120,7 @@ class UserController extends Controller
         $form = $this->createForm(UserCreateType::class, $data, [
             'languageCode' => $language->languageCode,
             'mainLanguageCode' => $language->languageCode,
+            'userCreateStruct' => $data,
         ]);
         $form->handleRequest($request);
 
@@ -152,6 +159,7 @@ class UserController extends Controller
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType
      * @throws \Ibexa\Core\Base\Exceptions\UnauthorizedException
      */
@@ -192,8 +200,10 @@ class UserController extends Controller
             $userUpdate,
             [
                 'location' => $location,
+                'content' => $this->contentService->loadContent($contentId),
                 'languageCode' => $language,
                 'mainLanguageCode' => $user->contentInfo->mainLanguageCode,
+                'userUpdateStruct' => $userUpdate,
             ]
         );
         $form->handleRequest($request);

--- a/src/bundle/Controller/UserController.php
+++ b/src/bundle/Controller/UserController.php
@@ -54,7 +54,6 @@ class UserController extends Controller
     /** @var \Ibexa\Contracts\ContentForms\Content\Form\Provider\GroupedContentFormFieldsProviderInterface */
     private $groupedContentFormFieldsProvider;
 
-    /** @var \Ibexa\Contracts\Core\Repository\ContentService */
     private ContentService $contentService;
 
     public function __construct(

--- a/src/bundle/Controller/UserController.php
+++ b/src/bundle/Controller/UserController.php
@@ -120,7 +120,7 @@ class UserController extends Controller
         $form = $this->createForm(UserCreateType::class, $data, [
             'languageCode' => $language->languageCode,
             'mainLanguageCode' => $language->languageCode,
-            'userCreateStruct' => $data,
+            'struct' => $data,
         ]);
         $form->handleRequest($request);
 
@@ -203,8 +203,8 @@ class UserController extends Controller
                 'content' => $this->contentService->loadContent($contentId),
                 'languageCode' => $language,
                 'mainLanguageCode' => $user->contentInfo->mainLanguageCode,
-                'userUpdateStruct' => $userUpdate,
-            ]
+                'struct' => $userUpdate,
+            ],
         );
         $form->handleRequest($request);
 

--- a/src/bundle/Controller/UserController.php
+++ b/src/bundle/Controller/UserController.php
@@ -55,7 +55,7 @@ class UserController extends Controller
     private $groupedContentFormFieldsProvider;
 
     /** @var \Ibexa\Contracts\Core\Repository\ContentService */
-    private $contentService;
+    private ContentService $contentService;
 
     public function __construct(
         ContentTypeService $contentTypeService,

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -99,14 +99,15 @@ services:
 
     Ibexa\Bundle\ContentForms\Controller\UserController:
         arguments:
-            - '@ibexa.api.service.content_type'
-            - '@ibexa.api.service.user'
-            - '@ibexa.api.service.location'
-            - '@ibexa.api.service.language'
-            - '@Ibexa\ContentForms\Form\ActionDispatcher\UserDispatcher'
-            - '@Ibexa\Contracts\Core\Repository\PermissionResolver'
-            - '@Ibexa\Core\MVC\Symfony\Locale\UserLanguagePreferenceProvider'
-            - '@Ibexa\ContentForms\Content\Form\Provider\GroupedContentFormFieldsProvider'
+            $contentTypeService: '@ibexa.api.service.content_type'
+            $userService: '@ibexa.api.service.user'
+            $locationService: '@ibexa.api.service.location'
+            $languageService: '@ibexa.api.service.language'
+            $userActionDispatcher: '@Ibexa\ContentForms\Form\ActionDispatcher\UserDispatcher'
+            $permissionResolver: '@Ibexa\Contracts\Core\Repository\PermissionResolver'
+            $userLanguagePreferenceProvider: '@Ibexa\Core\MVC\Symfony\Locale\UserLanguagePreferenceProvider'
+            $groupedContentFormFieldsProvider: '@Ibexa\ContentForms\Content\Form\Provider\GroupedContentFormFieldsProvider'
+            $contentService: '@ibexa.api.service.content'
         parent: Ibexa\Core\MVC\Symfony\Controller\Controller
         tags:
               - { name: controller.service_arguments }

--- a/src/lib/Event/ContentCreateFieldOptionsEvent.php
+++ b/src/lib/Event/ContentCreateFieldOptionsEvent.php
@@ -14,7 +14,6 @@ use Symfony\Component\Form\FormInterface;
 
 final class ContentCreateFieldOptionsEvent extends StructFieldOptionsEvent
 {
-    /** @var \Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct */
     private $contentCreateStruct;
 
     public function __construct(

--- a/src/lib/Event/ContentCreateFieldOptionsEvent.php
+++ b/src/lib/Event/ContentCreateFieldOptionsEvent.php
@@ -11,21 +11,11 @@ namespace Ibexa\ContentForms\Event;
 use Ibexa\Contracts\ContentForms\Data\Content\FieldData;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Contracts\EventDispatcher\Event;
 
-final class ContentCreateFieldOptionsEvent extends Event
+final class ContentCreateFieldOptionsEvent extends StructFieldOptionsEvent
 {
     /** @var \Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct */
     private $contentCreateStruct;
-
-    /** @var \Symfony\Component\Form\FormInterface */
-    private $parentForm;
-
-    /** @var \Ibexa\Contracts\ContentForms\Data\Content\FieldData */
-    private $fieldData;
-
-    /** @var array */
-    private $options;
 
     public function __construct(
         ContentCreateStruct $contentCreateStruct,
@@ -34,44 +24,13 @@ final class ContentCreateFieldOptionsEvent extends Event
         array $options
     ) {
         $this->contentCreateStruct = $contentCreateStruct;
-        $this->parentForm = $parentForm;
-        $this->fieldData = $fieldData;
-        $this->options = $options;
+
+        parent::__construct($parentForm, $fieldData, $options);
     }
 
     public function getContentCreateStruct(): ContentCreateStruct
     {
         return $this->contentCreateStruct;
-    }
-
-    public function getParentForm(): FormInterface
-    {
-        return $this->parentForm;
-    }
-
-    public function getFieldData(): FieldData
-    {
-        return $this->fieldData;
-    }
-
-    public function getOptions(): array
-    {
-        return $this->options;
-    }
-
-    public function setOptions(array $options): void
-    {
-        $this->options = $options;
-    }
-
-    public function setOption(string $option, $value): void
-    {
-        $this->options[$option] = $value;
-    }
-
-    public function getOption(string $option)
-    {
-        return $this->options[$option] ?? null;
     }
 }
 

--- a/src/lib/Event/ContentCreateFieldOptionsEvent.php
+++ b/src/lib/Event/ContentCreateFieldOptionsEvent.php
@@ -14,6 +14,7 @@ use Symfony\Component\Form\FormInterface;
 
 final class ContentCreateFieldOptionsEvent extends StructFieldOptionsEvent
 {
+    /** @var \Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct */
     private $contentCreateStruct;
 
     public function __construct(

--- a/src/lib/Event/ContentFormEvents.php
+++ b/src/lib/Event/ContentFormEvents.php
@@ -74,6 +74,16 @@ final class ContentFormEvents
      * Triggered when resolving Field Type options for content create form.
      */
     public const CONTENT_CREATE_FIELD_OPTIONS = 'content.create.field.options';
+
+    /**
+     * Triggered when resolving Field Type options for user edit form.
+     */
+    public const USER_EDIT_FIELD_OPTIONS = 'user.edit.field.options';
+
+    /**
+     * Triggered when resolving Field Type options for user create form.
+     */
+    public const USER_CREATE_FIELD_OPTIONS = 'user.create.field.options';
 }
 
 class_alias(ContentFormEvents::class, 'EzSystems\EzPlatformContentForms\Event\ContentFormEvents');

--- a/src/lib/Event/ContentUpdateFieldOptionsEvent.php
+++ b/src/lib/Event/ContentUpdateFieldOptionsEvent.php
@@ -12,24 +12,14 @@ use Ibexa\Contracts\ContentForms\Data\Content\FieldData;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentUpdateStruct;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Contracts\EventDispatcher\Event;
 
-final class ContentUpdateFieldOptionsEvent extends Event
+final class ContentUpdateFieldOptionsEvent extends StructFieldOptionsEvent
 {
     /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Content */
     private $content;
 
     /** @var \Ibexa\Contracts\Core\Repository\Values\Content\ContentUpdateStruct */
     private $contentUpdateStruct;
-
-    /** @var \Symfony\Component\Form\FormInterface */
-    private $parentForm;
-
-    /** @var \Ibexa\Contracts\ContentForms\Data\Content\FieldData */
-    private $fieldData;
-
-    /** @var array */
-    private $options;
 
     public function __construct(
         Content $content,
@@ -40,9 +30,8 @@ final class ContentUpdateFieldOptionsEvent extends Event
     ) {
         $this->content = $content;
         $this->contentUpdateStruct = $contentUpdateStruct;
-        $this->parentForm = $parentForm;
-        $this->fieldData = $fieldData;
-        $this->options = $options;
+
+        parent::__construct($parentForm, $fieldData, $options);
     }
 
     public function getContent(): Content
@@ -53,36 +42,6 @@ final class ContentUpdateFieldOptionsEvent extends Event
     public function getContentUpdateStruct(): ContentUpdateStruct
     {
         return $this->contentUpdateStruct;
-    }
-
-    public function getParentForm(): FormInterface
-    {
-        return $this->parentForm;
-    }
-
-    public function getFieldData(): FieldData
-    {
-        return $this->fieldData;
-    }
-
-    public function getOptions(): array
-    {
-        return $this->options;
-    }
-
-    public function setOptions(array $options): void
-    {
-        $this->options = $options;
-    }
-
-    public function setOption(string $option, $value): void
-    {
-        $this->options[$option] = $value;
-    }
-
-    public function getOption(string $option)
-    {
-        return $this->options[$option] ?? null;
     }
 }
 

--- a/src/lib/Event/StructFieldOptionsEvent.php
+++ b/src/lib/Event/StructFieldOptionsEvent.php
@@ -15,13 +15,13 @@ use Symfony\Contracts\EventDispatcher\Event;
 abstract class StructFieldOptionsEvent extends Event
 {
     /** @var \Symfony\Component\Form\FormInterface */
-    protected $parentForm;
+    protected FormInterface $parentForm;
 
     /** @var \Ibexa\Contracts\ContentForms\Data\Content\FieldData */
-    protected $fieldData;
+    protected FieldData $fieldData;
 
     /** @var array<string, mixed> */
-    protected $options;
+    protected array $options;
 
     public function __construct(
         FormInterface $parentForm,

--- a/src/lib/Event/StructFieldOptionsEvent.php
+++ b/src/lib/Event/StructFieldOptionsEvent.php
@@ -12,7 +12,7 @@ use Ibexa\Contracts\ContentForms\Data\Content\FieldData;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
-abstract class UserStructFieldOptionsEvent extends Event
+abstract class StructFieldOptionsEvent extends Event
 {
     /** @var \Symfony\Component\Form\FormInterface */
     protected $parentForm;
@@ -59,11 +59,17 @@ abstract class UserStructFieldOptionsEvent extends Event
         $this->options = $options;
     }
 
+    /**
+     * @param mixed $value
+     */
     public function setOption(string $option, $value): void
     {
         $this->options[$option] = $value;
     }
 
+    /**
+     * @return mixed|null
+     */
     public function getOption(string $option)
     {
         return $this->options[$option] ?? null;

--- a/src/lib/Event/StructFieldOptionsEvent.php
+++ b/src/lib/Event/StructFieldOptionsEvent.php
@@ -14,10 +14,8 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 abstract class StructFieldOptionsEvent extends Event
 {
-    /** @var \Symfony\Component\Form\FormInterface */
     protected FormInterface $parentForm;
 
-    /** @var \Ibexa\Contracts\ContentForms\Data\Content\FieldData */
     protected FieldData $fieldData;
 
     /** @var array<string, mixed> */

--- a/src/lib/Event/UserCreateFieldOptionsEvent.php
+++ b/src/lib/Event/UserCreateFieldOptionsEvent.php
@@ -11,21 +11,11 @@ namespace Ibexa\ContentForms\Event;
 use Ibexa\Contracts\ContentForms\Data\Content\FieldData;
 use Ibexa\Contracts\Core\Repository\Values\User\UserCreateStruct;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Contracts\EventDispatcher\Event;
 
-final class UserCreateFieldOptionsEvent extends Event
+final class UserCreateFieldOptionsEvent extends UserStructFieldOptionsEvent
 {
     /** @var \Ibexa\Contracts\Core\Repository\Values\User\UserCreateStruct */
     private $userCreateStruct;
-
-    /** @var \Symfony\Component\Form\FormInterface */
-    private $parentForm;
-
-    /** @var \Ibexa\Contracts\ContentForms\Data\Content\FieldData */
-    private $fieldData;
-
-    /** @var array<string, mixed> */
-    private $options;
 
     public function __construct(
         UserCreateStruct $userCreateStruct,
@@ -34,49 +24,12 @@ final class UserCreateFieldOptionsEvent extends Event
         array $options
     ) {
         $this->userCreateStruct = $userCreateStruct;
-        $this->parentForm = $parentForm;
-        $this->fieldData = $fieldData;
-        $this->options = $options;
+
+        parent::__construct($parentForm, $fieldData, $options);
     }
 
     public function getUserCreateStruct(): UserCreateStruct
     {
         return $this->userCreateStruct;
-    }
-
-    public function getParentForm(): FormInterface
-    {
-        return $this->parentForm;
-    }
-
-    public function getFieldData(): FieldData
-    {
-        return $this->fieldData;
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    public function getOptions(): array
-    {
-        return $this->options;
-    }
-
-    /**
-     * @param array<string, mixed> $options
-     */
-    public function setOptions(array $options): void
-    {
-        $this->options = $options;
-    }
-
-    public function setOption(string $option, $value): void
-    {
-        $this->options[$option] = $value;
-    }
-
-    public function getOption(string $option)
-    {
-        return $this->options[$option] ?? null;
     }
 }

--- a/src/lib/Event/UserCreateFieldOptionsEvent.php
+++ b/src/lib/Event/UserCreateFieldOptionsEvent.php
@@ -14,7 +14,6 @@ use Symfony\Component\Form\FormInterface;
 
 final class UserCreateFieldOptionsEvent extends StructFieldOptionsEvent
 {
-    /** @var \Ibexa\Contracts\Core\Repository\Values\User\UserCreateStruct */
     private UserCreateStruct $userCreateStruct;
 
     public function __construct(

--- a/src/lib/Event/UserCreateFieldOptionsEvent.php
+++ b/src/lib/Event/UserCreateFieldOptionsEvent.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\FormInterface;
 final class UserCreateFieldOptionsEvent extends StructFieldOptionsEvent
 {
     /** @var \Ibexa\Contracts\Core\Repository\Values\User\UserCreateStruct */
-    private $userCreateStruct;
+    private UserCreateStruct $userCreateStruct;
 
     public function __construct(
         UserCreateStruct $userCreateStruct,

--- a/src/lib/Event/UserCreateFieldOptionsEvent.php
+++ b/src/lib/Event/UserCreateFieldOptionsEvent.php
@@ -12,7 +12,7 @@ use Ibexa\Contracts\ContentForms\Data\Content\FieldData;
 use Ibexa\Contracts\Core\Repository\Values\User\UserCreateStruct;
 use Symfony\Component\Form\FormInterface;
 
-final class UserCreateFieldOptionsEvent extends UserStructFieldOptionsEvent
+final class UserCreateFieldOptionsEvent extends StructFieldOptionsEvent
 {
     /** @var \Ibexa\Contracts\Core\Repository\Values\User\UserCreateStruct */
     private $userCreateStruct;

--- a/src/lib/Event/UserCreateFieldOptionsEvent.php
+++ b/src/lib/Event/UserCreateFieldOptionsEvent.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\ContentForms\Event;
+
+use Ibexa\Contracts\ContentForms\Data\Content\FieldData;
+use Ibexa\Contracts\Core\Repository\Values\User\UserCreateStruct;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class UserCreateFieldOptionsEvent extends Event
+{
+    /** @var \Ibexa\Contracts\Core\Repository\Values\User\UserCreateStruct */
+    private $userCreateStruct;
+
+    /** @var \Symfony\Component\Form\FormInterface */
+    private $parentForm;
+
+    /** @var \Ibexa\Contracts\ContentForms\Data\Content\FieldData */
+    private $fieldData;
+
+    /** @var array<string, mixed> */
+    private $options;
+
+    public function __construct(
+        UserCreateStruct $userCreateStruct,
+        FormInterface $parentForm,
+        FieldData $fieldData,
+        array $options
+    ) {
+        $this->userCreateStruct = $userCreateStruct;
+        $this->parentForm = $parentForm;
+        $this->fieldData = $fieldData;
+        $this->options = $options;
+    }
+
+    public function getUserCreateStruct(): UserCreateStruct
+    {
+        return $this->userCreateStruct;
+    }
+
+    public function getParentForm(): FormInterface
+    {
+        return $this->parentForm;
+    }
+
+    public function getFieldData(): FieldData
+    {
+        return $this->fieldData;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function setOptions(array $options): void
+    {
+        $this->options = $options;
+    }
+
+    public function setOption(string $option, $value): void
+    {
+        $this->options[$option] = $value;
+    }
+
+    public function getOption(string $option)
+    {
+        return $this->options[$option] ?? null;
+    }
+}

--- a/src/lib/Event/UserStructFieldOptionsEvent.php
+++ b/src/lib/Event/UserStructFieldOptionsEvent.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\ContentForms\Event;
+
+use Ibexa\Contracts\ContentForms\Data\Content\FieldData;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+abstract class UserStructFieldOptionsEvent extends Event
+{
+    /** @var \Symfony\Component\Form\FormInterface */
+    protected $parentForm;
+
+    /** @var \Ibexa\Contracts\ContentForms\Data\Content\FieldData */
+    protected $fieldData;
+
+    /** @var array<string, mixed> */
+    protected $options;
+
+    public function __construct(
+        FormInterface $parentForm,
+        FieldData $fieldData,
+        array $options
+    ) {
+        $this->parentForm = $parentForm;
+        $this->fieldData = $fieldData;
+        $this->options = $options;
+    }
+
+    public function getParentForm(): FormInterface
+    {
+        return $this->parentForm;
+    }
+
+    public function getFieldData(): FieldData
+    {
+        return $this->fieldData;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function setOptions(array $options): void
+    {
+        $this->options = $options;
+    }
+
+    public function setOption(string $option, $value): void
+    {
+        $this->options[$option] = $value;
+    }
+
+    public function getOption(string $option)
+    {
+        return $this->options[$option] ?? null;
+    }
+}

--- a/src/lib/Event/UserUpdateFieldOptionsEvent.php
+++ b/src/lib/Event/UserUpdateFieldOptionsEvent.php
@@ -15,10 +15,8 @@ use Symfony\Component\Form\FormInterface;
 
 final class UserUpdateFieldOptionsEvent extends StructFieldOptionsEvent
 {
-    /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Content */
     private Content $content;
 
-    /** @var \Ibexa\Contracts\Core\Repository\Values\User\UserUpdateStruct */
     private UserUpdateStruct $userUpdateStruct;
 
     public function __construct(

--- a/src/lib/Event/UserUpdateFieldOptionsEvent.php
+++ b/src/lib/Event/UserUpdateFieldOptionsEvent.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\ContentForms\Event;
+
+use Ibexa\Contracts\ContentForms\Data\Content\FieldData;
+use Ibexa\Contracts\Core\Repository\Values\Content\Content;
+use Ibexa\Contracts\Core\Repository\Values\User\UserUpdateStruct;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class UserUpdateFieldOptionsEvent extends Event
+{
+    /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Content */
+    private $content;
+
+    /** @var \Ibexa\Contracts\Core\Repository\Values\User\UserUpdateStruct */
+    private $userUpdateStruct;
+
+    /** @var \Symfony\Component\Form\FormInterface */
+    private $parentForm;
+
+    /** @var \Ibexa\Contracts\ContentForms\Data\Content\FieldData */
+    private $fieldData;
+
+    /** @var array<string, mixed> */
+    private $options;
+
+    public function __construct(
+        Content $content,
+        UserUpdateStruct $userUpdateStruct,
+        FormInterface $parentForm,
+        FieldData $fieldData,
+        array $options
+    ) {
+        $this->content = $content;
+        $this->userUpdateStruct = $userUpdateStruct;
+        $this->parentForm = $parentForm;
+        $this->fieldData = $fieldData;
+        $this->options = $options;
+    }
+
+    public function getContent(): Content
+    {
+        return $this->content;
+    }
+
+    public function setContent(Content $content): void
+    {
+        $this->content = $content;
+    }
+
+    public function getUserUpdateStruct(): UserUpdateStruct
+    {
+        return $this->userUpdateStruct;
+    }
+
+    public function getParentForm(): FormInterface
+    {
+        return $this->parentForm;
+    }
+
+    public function getFieldData(): FieldData
+    {
+        return $this->fieldData;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function setOptions(array $options): void
+    {
+        $this->options = $options;
+    }
+
+    public function setOption(string $option, $value): void
+    {
+        $this->options[$option] = $value;
+    }
+
+    public function getOption(string $option)
+    {
+        return $this->options[$option] ?? null;
+    }
+}

--- a/src/lib/Event/UserUpdateFieldOptionsEvent.php
+++ b/src/lib/Event/UserUpdateFieldOptionsEvent.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\User\UserUpdateStruct;
 use Symfony\Component\Form\FormInterface;
 
-final class UserUpdateFieldOptionsEvent extends UserStructFieldOptionsEvent
+final class UserUpdateFieldOptionsEvent extends StructFieldOptionsEvent
 {
     /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Content */
     private $content;

--- a/src/lib/Event/UserUpdateFieldOptionsEvent.php
+++ b/src/lib/Event/UserUpdateFieldOptionsEvent.php
@@ -12,24 +12,14 @@ use Ibexa\Contracts\ContentForms\Data\Content\FieldData;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\User\UserUpdateStruct;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Contracts\EventDispatcher\Event;
 
-final class UserUpdateFieldOptionsEvent extends Event
+final class UserUpdateFieldOptionsEvent extends UserStructFieldOptionsEvent
 {
     /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Content */
     private $content;
 
     /** @var \Ibexa\Contracts\Core\Repository\Values\User\UserUpdateStruct */
     private $userUpdateStruct;
-
-    /** @var \Symfony\Component\Form\FormInterface */
-    private $parentForm;
-
-    /** @var \Ibexa\Contracts\ContentForms\Data\Content\FieldData */
-    private $fieldData;
-
-    /** @var array<string, mixed> */
-    private $options;
 
     public function __construct(
         Content $content,
@@ -40,9 +30,8 @@ final class UserUpdateFieldOptionsEvent extends Event
     ) {
         $this->content = $content;
         $this->userUpdateStruct = $userUpdateStruct;
-        $this->parentForm = $parentForm;
-        $this->fieldData = $fieldData;
-        $this->options = $options;
+
+        parent::__construct($parentForm, $fieldData, $options);
     }
 
     public function getContent(): Content
@@ -50,49 +39,8 @@ final class UserUpdateFieldOptionsEvent extends Event
         return $this->content;
     }
 
-    public function setContent(Content $content): void
-    {
-        $this->content = $content;
-    }
-
     public function getUserUpdateStruct(): UserUpdateStruct
     {
         return $this->userUpdateStruct;
-    }
-
-    public function getParentForm(): FormInterface
-    {
-        return $this->parentForm;
-    }
-
-    public function getFieldData(): FieldData
-    {
-        return $this->fieldData;
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    public function getOptions(): array
-    {
-        return $this->options;
-    }
-
-    /**
-     * @param array<string, mixed> $options
-     */
-    public function setOptions(array $options): void
-    {
-        $this->options = $options;
-    }
-
-    public function setOption(string $option, $value): void
-    {
-        $this->options[$option] = $value;
-    }
-
-    public function getOption(string $option)
-    {
-        return $this->options[$option] ?? null;
     }
 }

--- a/src/lib/Event/UserUpdateFieldOptionsEvent.php
+++ b/src/lib/Event/UserUpdateFieldOptionsEvent.php
@@ -16,10 +16,10 @@ use Symfony\Component\Form\FormInterface;
 final class UserUpdateFieldOptionsEvent extends StructFieldOptionsEvent
 {
     /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Content */
-    private $content;
+    private Content $content;
 
     /** @var \Ibexa\Contracts\Core\Repository\Values\User\UserUpdateStruct */
-    private $userUpdateStruct;
+    private UserUpdateStruct $userUpdateStruct;
 
     public function __construct(
         Content $content,

--- a/src/lib/Form/Type/Content/BaseContentType.php
+++ b/src/lib/Form/Type/Content/BaseContentType.php
@@ -49,8 +49,6 @@ class BaseContentType extends AbstractType
                     'content' => $options['content'] ?? null,
                     'contentCreateStruct' => $options['contentCreateStruct'] ?? null, // deprecated
                     'contentUpdateStruct' => $options['contentUpdateStruct'] ?? null, // deprecated
-                    'userCreateStruct' => $options['userCreateStruct'] ?? null, // deprecated
-                    'userUpdateStruct' => $options['userUpdateStruct'] ?? null, // deprecated
                     'struct' => $options['struct'],
                 ],
             ])

--- a/src/lib/Form/Type/Content/BaseContentType.php
+++ b/src/lib/Form/Type/Content/BaseContentType.php
@@ -8,12 +8,17 @@ declare(strict_types=1);
 
 namespace Ibexa\ContentForms\Form\Type\Content;
 
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct;
+use Ibexa\Contracts\Core\Repository\Values\User\UserCreateStruct;
+use Ibexa\Contracts\Core\Repository\Values\User\UserUpdateStruct;
+use Ibexa\Core\Repository\Values\Content\ContentUpdateStruct;
 use JMS\TranslationBundle\Annotation\Desc;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -42,10 +47,11 @@ class BaseContentType extends AbstractType
                     'mainLanguageCode' => $options['mainLanguageCode'],
                     'location' => $options['location'] ?? null,
                     'content' => $options['content'] ?? null,
-                    'contentCreateStruct' => $options['contentCreateStruct'] ?? null,
-                    'contentUpdateStruct' => $options['contentUpdateStruct'] ?? null,
-                    'userCreateStruct' => $options['userCreateStruct'] ?? null,
-                    'userUpdateStruct' => $options['userUpdateStruct'] ?? null,
+                    'contentCreateStruct' => $options['contentCreateStruct'] ?? null, // deprecated
+                    'contentUpdateStruct' => $options['contentUpdateStruct'] ?? null, // deprecated
+                    'userCreateStruct' => $options['userCreateStruct'] ?? null, // deprecated
+                    'userUpdateStruct' => $options['userUpdateStruct'] ?? null, // deprecated
+                    'struct' => $options['struct'],
                 ],
             ])
             ->add('redirectUrlAfterPublish', HiddenType::class, [
@@ -63,8 +69,27 @@ class BaseContentType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver
-            ->setDefaults(['translation_domain' => 'ibexa_content_forms_content'])
-            ->setRequired(['languageCode', 'mainLanguageCode']);
+            ->setDefaults([
+                'translation_domain' => 'ibexa_content_forms_content',
+                'struct' => null,
+            ])
+            ->setAllowedTypes(
+                'struct',
+                [
+                    'null',
+                    ContentCreateStruct::class,
+                    ContentUpdateStruct::class,
+                    UserCreateStruct::class,
+                    UserUpdateStruct::class,
+                ],
+            )
+            ->setRequired(['languageCode', 'mainLanguageCode', 'struct'])
+            ->setNormalizer('struct', static function (Options $options, $value) {
+                return $options['userUpdateStruct']
+                    ?? $options['userCreateStruct']
+                        ?? $options['contentUpdateStruct']
+                            ?? $options['contentCreateStruct'];
+            });
     }
 }
 

--- a/src/lib/Form/Type/Content/BaseContentType.php
+++ b/src/lib/Form/Type/Content/BaseContentType.php
@@ -78,6 +78,7 @@ class BaseContentType extends AbstractType
                     ?? $options['userCreateStruct']
                     ?? $options['contentUpdateStruct']
                     ?? $options['contentCreateStruct']
+                    ?? $options['data']
                     ?? null;
             })
             ->setDefaults([

--- a/src/lib/Form/Type/Content/BaseContentType.php
+++ b/src/lib/Form/Type/Content/BaseContentType.php
@@ -44,6 +44,8 @@ class BaseContentType extends AbstractType
                     'content' => $options['content'] ?? null,
                     'contentCreateStruct' => $options['contentCreateStruct'] ?? null,
                     'contentUpdateStruct' => $options['contentUpdateStruct'] ?? null,
+                    'userCreateStruct' => $options['userCreateStruct'] ?? null,
+                    'userUpdateStruct' => $options['userUpdateStruct'] ?? null,
                 ],
             ])
             ->add('redirectUrlAfterPublish', HiddenType::class, [

--- a/src/lib/Form/Type/Content/BaseContentType.php
+++ b/src/lib/Form/Type/Content/BaseContentType.php
@@ -78,7 +78,6 @@ class BaseContentType extends AbstractType
                     ?? $options['userCreateStruct']
                     ?? $options['contentUpdateStruct']
                     ?? $options['contentCreateStruct']
-                    ?? $options['data']
                     ?? null;
             })
             ->setDefaults([
@@ -89,6 +88,7 @@ class BaseContentType extends AbstractType
             ->setAllowedTypes(
                 'struct',
                 [
+                    'null',
                     ContentCreateStruct::class,
                     ContentUpdateStruct::class,
                     UserCreateStruct::class,

--- a/src/lib/Form/Type/Content/BaseContentType.php
+++ b/src/lib/Form/Type/Content/BaseContentType.php
@@ -9,9 +9,9 @@ declare(strict_types=1);
 namespace Ibexa\ContentForms\Form\Type\Content;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentUpdateStruct;
 use Ibexa\Contracts\Core\Repository\Values\User\UserCreateStruct;
 use Ibexa\Contracts\Core\Repository\Values\User\UserUpdateStruct;
-use Ibexa\Core\Repository\Values\Content\ContentUpdateStruct;
 use JMS\TranslationBundle\Annotation\Desc;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -47,8 +47,8 @@ class BaseContentType extends AbstractType
                     'mainLanguageCode' => $options['mainLanguageCode'],
                     'location' => $options['location'] ?? null,
                     'content' => $options['content'] ?? null,
-                    'contentCreateStruct' => $options['contentCreateStruct'] ?? null, // deprecated
-                    'contentUpdateStruct' => $options['contentUpdateStruct'] ?? null, // deprecated
+                    'contentCreateStruct' => $options['contentCreateStruct'] ?? null,
+                    'contentUpdateStruct' => $options['contentUpdateStruct'] ?? null,
                     'struct' => $options['struct'],
                 ],
             ])
@@ -70,6 +70,8 @@ class BaseContentType extends AbstractType
             ->setDefaults([
                 'translation_domain' => 'ibexa_content_forms_content',
                 'struct' => null,
+                'contentCreateStruct' => null,
+                'contentUpdateStruct' => null,
             ])
             ->setAllowedTypes(
                 'struct',
@@ -83,11 +85,36 @@ class BaseContentType extends AbstractType
             )
             ->setRequired(['languageCode', 'mainLanguageCode', 'struct'])
             ->setNormalizer('struct', static function (Options $options, $value) {
-                return $options['userUpdateStruct']
-                    ?? $options['userCreateStruct']
+                if ($value !== null) {
+                    return $value;
+                }
+
+                if (isset($options['userUpdateStruct'])
+                    xor isset($options['userCreateStruct'])
+                    xor isset($options['contentUpdateStruct'])
+                    xor isset($options['contentCreateStruct'])
+                ) {
+                    return $options['userUpdateStruct']
+                        ?? $options['userCreateStruct']
                         ?? $options['contentUpdateStruct']
-                            ?? $options['contentCreateStruct'];
-            });
+                        ?? $options['contentCreateStruct']
+                    ;
+                }
+
+                return null;
+            })
+            ->setDeprecated(
+                'contentCreateStruct',
+                'ibexa/content-forms',
+                'v4.6.4',
+                'The option "%name%" is deprecated, use "struct" instead.'
+            )
+            ->setDeprecated(
+                'contentUpdateStruct',
+                'ibexa/content-forms',
+                'v4.6.4',
+                'The option "%name%" is deprecated, use "struct" instead.'
+            );
     }
 }
 

--- a/src/lib/Form/Type/Content/BaseContentType.php
+++ b/src/lib/Form/Type/Content/BaseContentType.php
@@ -51,6 +51,7 @@ class BaseContentType extends AbstractType
                     'contentUpdateStruct' => $options['contentUpdateStruct'] ?? null,
                     'struct' => $options['struct'],
                 ],
+                'translation_domain' => 'ibexa_content_forms_content',
             ])
             ->add('redirectUrlAfterPublish', HiddenType::class, [
                 'required' => false,

--- a/src/lib/Form/Type/Content/BaseContentType.php
+++ b/src/lib/Form/Type/Content/BaseContentType.php
@@ -67,23 +67,21 @@ class BaseContentType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver
+            ->setRequired(['languageCode', 'mainLanguageCode', 'struct'])
             ->setDefaults([
                 'translation_domain' => 'ibexa_content_forms_content',
-                'struct' => null,
                 'contentCreateStruct' => null,
                 'contentUpdateStruct' => null,
             ])
             ->setAllowedTypes(
                 'struct',
                 [
-                    'null',
                     ContentCreateStruct::class,
                     ContentUpdateStruct::class,
                     UserCreateStruct::class,
                     UserUpdateStruct::class,
                 ],
             )
-            ->setRequired(['languageCode', 'mainLanguageCode', 'struct'])
             ->setNormalizer('struct', static function (Options $options, $value) {
                 if ($value !== null) {
                     return $value;

--- a/src/lib/Form/Type/Content/BaseContentType.php
+++ b/src/lib/Form/Type/Content/BaseContentType.php
@@ -68,41 +68,31 @@ class BaseContentType extends AbstractType
     {
         $resolver
             ->setRequired(['languageCode', 'mainLanguageCode', 'struct'])
+            ->setDefault('struct', static function (Options $options, $value) {
+                if ($value !== null) {
+                    return $value;
+                }
+
+                return $options['userUpdateStruct']
+                    ?? $options['userCreateStruct']
+                    ?? $options['contentUpdateStruct']
+                    ?? $options['contentCreateStruct']
+                    ?? null;
+            })
             ->setDefaults([
                 'translation_domain' => 'ibexa_content_forms_content',
                 'contentCreateStruct' => null,
                 'contentUpdateStruct' => null,
-                'struct' => null,
             ])
             ->setAllowedTypes(
                 'struct',
                 [
-                    'null',
                     ContentCreateStruct::class,
                     ContentUpdateStruct::class,
                     UserCreateStruct::class,
                     UserUpdateStruct::class,
                 ],
             )
-            ->addNormalizer('struct', static function (Options $options, $value) {
-                if ($value !== null) {
-                    return $value;
-                }
-
-                if (isset($options['userUpdateStruct'])
-                    xor isset($options['userCreateStruct'])
-                    xor isset($options['contentUpdateStruct'])
-                    xor isset($options['contentCreateStruct'])
-                ) {
-                    return $options['userUpdateStruct']
-                        ?? $options['userCreateStruct']
-                        ?? $options['contentUpdateStruct']
-                        ?? $options['contentCreateStruct']
-                    ;
-                }
-
-                return null;
-            }, true)
             ->setDeprecated(
                 'contentCreateStruct',
                 'ibexa/content-forms',

--- a/src/lib/Form/Type/Content/BaseContentType.php
+++ b/src/lib/Form/Type/Content/BaseContentType.php
@@ -72,17 +72,19 @@ class BaseContentType extends AbstractType
                 'translation_domain' => 'ibexa_content_forms_content',
                 'contentCreateStruct' => null,
                 'contentUpdateStruct' => null,
+                'struct' => null,
             ])
             ->setAllowedTypes(
                 'struct',
                 [
+                    'null',
                     ContentCreateStruct::class,
                     ContentUpdateStruct::class,
                     UserCreateStruct::class,
                     UserUpdateStruct::class,
                 ],
             )
-            ->setNormalizer('struct', static function (Options $options, $value) {
+            ->addNormalizer('struct', static function (Options $options, $value) {
                 if ($value !== null) {
                     return $value;
                 }
@@ -100,7 +102,7 @@ class BaseContentType extends AbstractType
                 }
 
                 return null;
-            })
+            }, true)
             ->setDeprecated(
                 'contentCreateStruct',
                 'ibexa/content-forms',

--- a/src/lib/Form/Type/Content/ContentFieldType.php
+++ b/src/lib/Form/Type/Content/ContentFieldType.php
@@ -46,14 +46,15 @@ class ContentFieldType extends AbstractType
             ->setDefaults([
                 'content' => null,
                 'location' => null,
-                'contentCreateStruct' => null,
-                'contentUpdateStruct' => null,
-                'userCreateStruct' => null,
-                'userUpdateStruct' => null,
+                'contentCreateStruct' => null, // deprecated
+                'contentUpdateStruct' => null, // deprecated
+                'userCreateStruct' => null, // deprecated
+                'userUpdateStruct' => null, // deprecated
                 'data_class' => FieldData::class,
                 'translation_domain' => 'ibexa_content_forms_content',
+                'struct' => null,
             ])
-            ->setRequired(['languageCode', 'mainLanguageCode']);
+            ->setRequired(['languageCode', 'mainLanguageCode', 'struct']);
     }
 
     public function buildView(FormView $view, FormInterface $form, array $options)

--- a/src/lib/Form/Type/Content/ContentFieldType.php
+++ b/src/lib/Form/Type/Content/ContentFieldType.php
@@ -10,6 +10,10 @@ namespace Ibexa\ContentForms\Form\Type\Content;
 
 use Ibexa\ContentForms\FieldType\FieldTypeFormMapperDispatcherInterface;
 use Ibexa\Contracts\ContentForms\Data\Content\FieldData;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentUpdateStruct;
+use Ibexa\Contracts\Core\Repository\Values\User\UserCreateStruct;
+use Ibexa\Contracts\Core\Repository\Values\User\UserUpdateStruct;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
@@ -46,13 +50,37 @@ class ContentFieldType extends AbstractType
             ->setDefaults([
                 'content' => null,
                 'location' => null,
-                'contentCreateStruct' => null, // deprecated
-                'contentUpdateStruct' => null, // deprecated
+                'contentCreateStruct' => null,
+                'contentUpdateStruct' => null,
                 'data_class' => FieldData::class,
                 'translation_domain' => 'ibexa_content_forms_content',
                 'struct' => null,
             ])
-            ->setRequired(['languageCode', 'mainLanguageCode', 'struct']);
+            ->setAllowedTypes(
+                'struct',
+                [
+                    'null',
+                    ContentCreateStruct::class,
+                    ContentUpdateStruct::class,
+                    UserCreateStruct::class,
+                    UserUpdateStruct::class,
+                ],
+            )
+            ->setAllowedTypes('contentCreateStruct', ['null', ContentCreateStruct::class])
+            ->setAllowedTypes('contentUpdateStruct', ['null', ContentUpdateStruct::class])
+            ->setRequired(['languageCode', 'mainLanguageCode', 'struct'])
+            ->setDeprecated(
+                'contentCreateStruct',
+                'ibexa/content-forms',
+                'v4.6.4',
+                'The option "%name%" is deprecated, use "struct" instead.'
+            )
+            ->setDeprecated(
+                'contentUpdateStruct',
+                'ibexa/content-forms',
+                'v4.6.4',
+                'The option "%name%" is deprecated, use "struct" instead.'
+            );
     }
 
     public function buildView(FormView $view, FormInterface $form, array $options)

--- a/src/lib/Form/Type/Content/ContentFieldType.php
+++ b/src/lib/Form/Type/Content/ContentFieldType.php
@@ -48,6 +48,8 @@ class ContentFieldType extends AbstractType
                 'location' => null,
                 'contentCreateStruct' => null,
                 'contentUpdateStruct' => null,
+                'userCreateStruct' => null,
+                'userUpdateStruct' => null,
                 'data_class' => FieldData::class,
                 'translation_domain' => 'ibexa_content_forms_content',
             ])

--- a/src/lib/Form/Type/Content/ContentFieldType.php
+++ b/src/lib/Form/Type/Content/ContentFieldType.php
@@ -48,8 +48,6 @@ class ContentFieldType extends AbstractType
                 'location' => null,
                 'contentCreateStruct' => null, // deprecated
                 'contentUpdateStruct' => null, // deprecated
-                'userCreateStruct' => null, // deprecated
-                'userUpdateStruct' => null, // deprecated
                 'data_class' => FieldData::class,
                 'translation_domain' => 'ibexa_content_forms_content',
                 'struct' => null,

--- a/src/lib/Form/Type/Content/ContentFieldType.php
+++ b/src/lib/Form/Type/Content/ContentFieldType.php
@@ -47,6 +47,7 @@ class ContentFieldType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver
+            ->setRequired(['languageCode', 'mainLanguageCode', 'struct'])
             ->setDefaults([
                 'content' => null,
                 'location' => null,
@@ -54,12 +55,10 @@ class ContentFieldType extends AbstractType
                 'contentUpdateStruct' => null,
                 'data_class' => FieldData::class,
                 'translation_domain' => 'ibexa_content_forms_content',
-                'struct' => null,
             ])
             ->setAllowedTypes(
                 'struct',
                 [
-                    'null',
                     ContentCreateStruct::class,
                     ContentUpdateStruct::class,
                     UserCreateStruct::class,
@@ -68,7 +67,6 @@ class ContentFieldType extends AbstractType
             )
             ->setAllowedTypes('contentCreateStruct', ['null', ContentCreateStruct::class])
             ->setAllowedTypes('contentUpdateStruct', ['null', ContentUpdateStruct::class])
-            ->setRequired(['languageCode', 'mainLanguageCode', 'struct'])
             ->setDeprecated(
                 'contentCreateStruct',
                 'ibexa/content-forms',

--- a/src/lib/Form/Type/Content/ContentFieldType.php
+++ b/src/lib/Form/Type/Content/ContentFieldType.php
@@ -59,6 +59,7 @@ class ContentFieldType extends AbstractType
             ->setAllowedTypes(
                 'struct',
                 [
+                    'null',
                     ContentCreateStruct::class,
                     ContentUpdateStruct::class,
                     UserCreateStruct::class,

--- a/src/lib/Form/Type/Content/FieldCollectionType.php
+++ b/src/lib/Form/Type/Content/FieldCollectionType.php
@@ -99,7 +99,6 @@ class FieldCollectionType extends CollectionType
         array $entryOptions,
         FormInterface $form
     ): array {
-        dump($entryOptions);
         if ($this->isContentUpdate($entryOptions)) {
             /** @var \Ibexa\ContentForms\Event\ContentUpdateFieldOptionsEvent $contentUpdateFieldOptionsEvent */
             $contentUpdateFieldOptionsEvent = $this->eventDispatcher->dispatch(

--- a/src/lib/Form/Type/Content/FieldCollectionType.php
+++ b/src/lib/Form/Type/Content/FieldCollectionType.php
@@ -14,6 +14,10 @@ use Ibexa\ContentForms\Event\ContentUpdateFieldOptionsEvent;
 use Ibexa\ContentForms\Event\UserCreateFieldOptionsEvent;
 use Ibexa\ContentForms\Event\UserUpdateFieldOptionsEvent;
 use Ibexa\Contracts\ContentForms\Data\Content\FieldData;
+use Ibexa\Contracts\Core\Repository\Values\User\UserUpdateStruct;
+use Ibexa\Core\Repository\Values\Content\ContentCreateStruct;
+use Ibexa\Core\Repository\Values\Content\ContentUpdateStruct;
+use Ibexa\Core\Repository\Values\User\UserCreateStruct;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
@@ -61,12 +65,12 @@ class FieldCollectionType extends CollectionType
 
     private function isContentCreate(array $entryOptions): bool
     {
-        return !empty($entryOptions['contentCreateStruct']);
+        return !empty($entryOptions['struct']) && $entryOptions['struct'] instanceof ContentCreateStruct;
     }
 
     private function isContentUpdate(array $entryOptions): bool
     {
-        return !empty($entryOptions['content']) && !empty($entryOptions['contentUpdateStruct']);
+        return !empty($entryOptions['struct']) && $entryOptions['struct'] instanceof ContentUpdateStruct;
     }
 
     /**
@@ -74,7 +78,7 @@ class FieldCollectionType extends CollectionType
      */
     private function isUserCreate(array $entryOptions): bool
     {
-        return !empty($entryOptions['userCreateStruct']);
+        return !empty($entryOptions['struct']) && $entryOptions['struct'] instanceof UserCreateStruct;
     }
 
     /**
@@ -82,25 +86,26 @@ class FieldCollectionType extends CollectionType
      */
     private function isUserUpdate(array $entryOptions): bool
     {
-        return !empty($entryOptions['userUpdateStruct']);
+        return !empty($entryOptions['struct']) && $entryOptions['struct'] instanceof UserUpdateStruct;
     }
 
     /**
      * @param array<string, mixed> $entryOptions
      *
-     * @return array<string, mixed> $entryOptions
+     * @return array<string, mixed>
      */
     private function dispatchFieldOptionsEvent(
         FieldData $entryData,
         array $entryOptions,
         FormInterface $form
     ): array {
+        dump($entryOptions);
         if ($this->isContentUpdate($entryOptions)) {
             /** @var \Ibexa\ContentForms\Event\ContentUpdateFieldOptionsEvent $contentUpdateFieldOptionsEvent */
             $contentUpdateFieldOptionsEvent = $this->eventDispatcher->dispatch(
                 new ContentUpdateFieldOptionsEvent(
                     $entryOptions['content'],
-                    $entryOptions['contentUpdateStruct'],
+                    $entryOptions['struct'],
                     $form,
                     $entryData,
                     $entryOptions
@@ -113,7 +118,7 @@ class FieldCollectionType extends CollectionType
             /** @var \Ibexa\ContentForms\Event\ContentCreateFieldOptionsEvent $contentUpdateFieldOptionsEvent */
             $contentCreateFieldOptionsEvent = $this->eventDispatcher->dispatch(
                 new ContentCreateFieldOptionsEvent(
-                    $entryOptions['contentCreateStruct'],
+                    $entryOptions['struct'],
                     $form,
                     $entryData,
                     $entryOptions
@@ -126,7 +131,7 @@ class FieldCollectionType extends CollectionType
             /** @var \Ibexa\ContentForms\Event\UserCreateFieldOptionsEvent $userCreateFieldOptionsEvent */
             $userCreateFieldOptionsEvent = $this->eventDispatcher->dispatch(
                 new UserCreateFieldOptionsEvent(
-                    $entryOptions['userCreateStruct'],
+                    $entryOptions['struct'],
                     $form,
                     $entryData,
                     $entryOptions
@@ -140,7 +145,7 @@ class FieldCollectionType extends CollectionType
             $userUpdateFieldOptionsEvent = $this->eventDispatcher->dispatch(
                 new UserUpdateFieldOptionsEvent(
                     $entryOptions['content'],
-                    $entryOptions['userUpdateStruct'],
+                    $entryOptions['struct'],
                     $form,
                     $entryData,
                     $entryOptions

--- a/src/lib/Form/Type/Content/FieldCollectionType.php
+++ b/src/lib/Form/Type/Content/FieldCollectionType.php
@@ -23,6 +23,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class FieldCollectionType extends CollectionType
@@ -61,6 +62,13 @@ class FieldCollectionType extends CollectionType
                 $form->add($name, $options['entry_type'], $entryOptions);
             }
         });
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        parent::configureOptions($resolver);
+
+        $resolver->setDefault('translation_domain', 'ibexa_content_forms_content');
     }
 
     /**

--- a/src/lib/Form/Type/User/UserCreateType.php
+++ b/src/lib/Form/Type/User/UserCreateType.php
@@ -47,8 +47,8 @@ class UserCreateType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
+            ->setRequired('struct')
             ->setDefaults([
-                'struct' => null,
                 'data_class' => UserCreateData::class,
                 'intent' => 'create',
                 'translation_domain' => 'ibexa_content_forms_user',

--- a/src/lib/Form/Type/User/UserCreateType.php
+++ b/src/lib/Form/Type/User/UserCreateType.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\ContentForms\Form\Type\User;
 
 use Ibexa\ContentForms\Data\User\UserCreateData;
+use Ibexa\Contracts\Core\Repository\Values\User\UserCreateStruct;
 use JMS\TranslationBundle\Annotation\Desc;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -47,11 +48,12 @@ class UserCreateType extends AbstractType
     {
         $resolver
             ->setDefaults([
-                'userCreateStruct' => null,
+                'struct' => null,
                 'data_class' => UserCreateData::class,
                 'intent' => 'create',
                 'translation_domain' => 'ibexa_content_forms_user',
-            ]);
+            ])
+            ->setAllowedTypes('struct', UserCreateStruct::class);
     }
 }
 

--- a/src/lib/Form/Type/User/UserCreateType.php
+++ b/src/lib/Form/Type/User/UserCreateType.php
@@ -43,10 +43,11 @@ class UserCreateType extends AbstractType
             ->add('create', SubmitType::class, ['label' => /** @Desc("Create") */ 'user.create']);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([
+                'userCreateStruct' => null,
                 'data_class' => UserCreateData::class,
                 'intent' => 'create',
                 'translation_domain' => 'ibexa_content_forms_user',

--- a/src/lib/Form/Type/User/UserUpdateType.php
+++ b/src/lib/Form/Type/User/UserUpdateType.php
@@ -47,10 +47,10 @@ class UserUpdateType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
+            ->setRequired('struct')
             ->setDefaults([
                 'location' => null,
                 'content' => null,
-                'struct' => null,
                 'data_class' => UserUpdateData::class,
                 'intent' => 'update',
                 'translation_domain' => 'ibexa_content_forms_user',

--- a/src/lib/Form/Type/User/UserUpdateType.php
+++ b/src/lib/Form/Type/User/UserUpdateType.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\ContentForms\Form\Type\User;
 
 use Ibexa\ContentForms\Data\User\UserUpdateData;
+use Ibexa\Contracts\Core\Repository\Values\User\UserUpdateStruct;
 use JMS\TranslationBundle\Annotation\Desc;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -49,11 +50,12 @@ class UserUpdateType extends AbstractType
             ->setDefaults([
                 'location' => null,
                 'content' => null,
-                'userUpdateStruct' => null,
+                'struct' => null,
                 'data_class' => UserUpdateData::class,
                 'intent' => 'update',
                 'translation_domain' => 'ibexa_content_forms_user',
-            ]);
+            ])
+            ->setAllowedTypes('struct', UserUpdateStruct::class);
     }
 }
 

--- a/src/lib/Form/Type/User/UserUpdateType.php
+++ b/src/lib/Form/Type/User/UserUpdateType.php
@@ -43,11 +43,13 @@ class UserUpdateType extends AbstractType
             ->add('update', SubmitType::class, ['label' => /** @Desc("Update") */ 'user.update']);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([
                 'location' => null,
+                'content' => null,
+                'userUpdateStruct' => null,
                 'data_class' => UserUpdateData::class,
                 'intent' => 'update',
                 'translation_domain' => 'ibexa_content_forms_user',


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       | [IBX-7935](https://issues.ibexa.co/browse/IBX-7935)   |
| **Type**             | bug                                                   |
| **Target version**   | `v4.6`                                                |
| **BC breaks**        | no                                                    |
| **Doc needed**       | no                                                    |

The `FieldPermissionChecker` (https://github.com/ibexa/permissions/blob/4.5/src/lib/EventSubscriber/FieldPermissionCheckSubscriber.php#L46-L47) doesn't account for User-related structs like `UserCreateStruct` or `UserUpdateStruct`, therefore those fields won't be disabled in case one is editing user content.

The following PR creates some necessary events and dispatches them accordingly in the `FieldCollectionType` class :https://github.com/ibexa/content-forms/blob/main/src/lib/Form/Type/Content/FieldCollectionType.php.

Related PR: https://github.com/ibexa/permissions/pull/17

#### Checklist:
- [X] Provided PR description.
- [X] Tested the solution manually.
- [ ] Provided automated test coverage.
- [X] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
