### PR TITLE
IBX-8034 Changed reading all content fields in mapToFormData so it does not rely on language code

### DIFF
--- a/src/lib/Data/Mapper/ContentUpdateMapper.php
+++ b/src/lib/Data/Mapper/ContentUpdateMapper.php
@@ -37,7 +37,10 @@ class ContentUpdateMapper implements FormDataMapperInterface
         $data = new ContentUpdateData(['contentDraft' => $contentDraft]);
         $data->initialLanguageCode = $languageCode;
 
-        $fields = $contentDraft->getFieldsByLanguage($languageCode);
+        $fields = [];
+        foreach ($contentDraft->getFields() as $field) {
+            $fields[$field->fieldDefIdentifier] = $field;
+        }
         $mainLanguageCode = $contentDraft->getVersionInfo()->getContentInfo()->getMainLanguage()->getLanguageCode();
 
         foreach ($params['contentType']->fieldDefinitions as $fieldDef) {


### PR DESCRIPTION
| :ticket: Issue | [IBX-8034](https://issues.ibexa.co/browse/IBX-8034) |
|----------------|-----------|

#### Description:
Changed reading all content fields in mapToFormData so it does not rely on language code because it caused exceptions when editing translations with address field 

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
