### PR TITLE
IBX-8119: Upgraded minimum PHP version to 8.3

### DIFF
--- a/.github/actions/composer-install/action.yaml
+++ b/.github/actions/composer-install/action.yaml
@@ -7,8 +7,8 @@ runs:
                 version=$(jq -r '.extra | ."branch-alias" | ."dev-main"' < composer.json)
                 echo "version=$version" >> $GITHUB_ENV
             shell: bash
-        -   uses: ramsey/composer-install@v2
+        -   uses: ramsey/composer-install@v3
             with:
-                dependency-versions: "highest"
+                dependency-versions: highest
             env:
                 COMPOSER_ROOT_VERSION: ${{ env.version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,9 +12,7 @@ jobs:
         name: Run code style check
         runs-on: "ubuntu-22.04"
         strategy:
-            matrix:
-                php:
-                    - '8.0'
+
         steps:
             - uses: actions/checkout@v4
 
@@ -40,8 +38,6 @@ jobs:
             fail-fast: false
             matrix:
                 php:
-                    - '7.4'
-                    - '8.0'
                     - '8.3'
 
         steps:
@@ -73,8 +69,6 @@ jobs:
             fail-fast: false
             matrix:
                 php:
-                    - '7.4'
-                    - '8.0'
                     - '8.3'
 
         steps:

--- a/composer.json
+++ b/composer.json
@@ -7,37 +7,37 @@
         "ezsystems/ezplatform-content-forms": "*"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": " >=8.3",
         "ext-json": "*",
-        "ibexa/core": "~5.0.0@dev",
-        "symfony/dependency-injection": "^5.0",
-        "symfony/http-kernel": "^5.0",
-        "symfony/http-foundation": "^5.0",
-        "symfony/options-resolver": "^5.0",
+        "ibexa/core": "~5.0.x-dev",
+        "jms/translation-bundle": "^1.5",
         "symfony/config": "^5.0",
-        "symfony/yaml": "^5.0",
+        "symfony/dependency-injection": "^5.0",
+        "symfony/event-dispatcher": "^5.0",
         "symfony/filesystem": "^5.0",
         "symfony/form": "^5.0",
-        "symfony/event-dispatcher": "^5.0",
-        "symfony/validator": "^5.0",
+        "symfony/http-foundation": "^5.0",
+        "symfony/http-kernel": "^5.0",
+        "symfony/options-resolver": "^5.0",
         "symfony/routing": "^5.0",
         "symfony/translation": " ^5.0",
-        "jms/translation-bundle": "^1.5"
+        "symfony/validator": "^5.0",
+        "symfony/yaml": "^5.0"
     },
     "require-dev": {
-        "ibexa/ci-scripts": "^0.2@dev",
-        "ibexa/behat": "~5.0.0@dev",
-        "ibexa/doctrine-schema": "~5.0.0@dev",
-        "ibexa/http-cache": "~5.0.0@dev",
-        "ibexa/notifications": "~5.0.x-dev",
-        "ibexa/rest": "~5.0.0@dev",
-        "ibexa/test-core": "~5.0.x-dev",
-        "ibexa/user": "^5.0.x-dev",
-        "phpunit/phpunit": "^8.2",
-        "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "behat/behat": "^3.5",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "ibexa/code-style": "^1.0"
+        "ibexa/behat": "~5.0.x-dev",
+        "ibexa/ci-scripts": "^0.2@dev",
+        "ibexa/code-style": "^1.0",
+        "ibexa/doctrine-schema": "~5.0.x-dev",
+        "ibexa/http-cache": "~5.0.x-dev",
+        "ibexa/notifications": "~5.0.x-dev",
+        "ibexa/rest": "~5.0.x-dev",
+        "ibexa/test-core": "~5.0.x-dev",
+        "ibexa/user": "^5.0.x-dev",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.0",
+        "phpunit/phpunit": "^8.2"
     },
     "autoload": {
         "psr-4": {
@@ -66,7 +66,8 @@
     "config": {
         "allow-plugins": {
             "*/*": false
-        }
+        },
+        "sort-packages": true
     },
     "scripts": {
         "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php -v --show-progress=dots",


### PR DESCRIPTION
| :ticket: Issue | IBX-8119 |
|----------------|-----------|

#### Description:

This PR bumps the minimum required version of PHP to 8.3.
`>=8.3` version constraint is set with expectation of compatibility with version PHP 9.

Additionally, this PR:
 * enforces sorting of packages within `require` and `require-dev` sections of composer.json file
 * replaces `~5.0.0@dev` declarations with their more development friendly `~5.0.x-dev`.
 * adjusts github workflows to match new PHP version
 * updates GH action versions

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!--
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes)
-->
