### PR TITLE
IBX-7935: Allowed null value for struct in user Types

### DIFF
--- a/src/lib/Form/Type/Content/BaseContentType.php
+++ b/src/lib/Form/Type/Content/BaseContentType.php
@@ -68,10 +68,16 @@ class BaseContentType extends AbstractType
     {
         $resolver
             ->setRequired(['languageCode', 'mainLanguageCode', 'struct'])
-            ->setDefault('struct', static function (Options $options, $value) {
+            ->setDefault('struct', static function (Options $options, ?ContentStruct $value) {
                 if ($value !== null) {
                     return $value;
                 }
+
+                trigger_deprecation(
+                    'ibexa/content-forms',
+                    'v4.6',
+                    'The option "struct" with null value is deprecated and will be required in v5.0.'
+                );
 
                 return $options['contentUpdateStruct']
                     ?? $options['contentCreateStruct']
@@ -101,20 +107,6 @@ class BaseContentType extends AbstractType
                 'ibexa/content-forms',
                 'v4.6.4',
                 'The option "%name%" is deprecated, use "struct" instead.'
-            )
-            ->setNormalizer(
-                'struct',
-                static function (Options $options, ?ContentStruct $value): ?ContentStruct {
-                    if ($value === null) {
-                        trigger_deprecation(
-                            'ibexa/content-forms',
-                            'v4.6',
-                            'The option "struct" with null value is deprecated and will be required in v5.0.'
-                        );
-                    }
-
-                    return $value;
-                }
             );
     }
 }

--- a/src/lib/Form/Type/Content/BaseContentType.php
+++ b/src/lib/Form/Type/Content/BaseContentType.php
@@ -9,9 +9,8 @@ declare(strict_types=1);
 namespace Ibexa\ContentForms\Form\Type\Content;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentStruct;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentUpdateStruct;
-use Ibexa\Contracts\Core\Repository\Values\User\UserCreateStruct;
-use Ibexa\Contracts\Core\Repository\Values\User\UserUpdateStruct;
 use JMS\TranslationBundle\Annotation\Desc;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -103,8 +102,9 @@ class BaseContentType extends AbstractType
                 'v4.6.4',
                 'The option "%name%" is deprecated, use "struct" instead.'
             )
-            ->setNormalizer('struct',
-                static function (Options $options, ?UserCreateStruct $value): ?UserCreateStruct {
+            ->setNormalizer(
+                'struct',
+                static function (Options $options, ?ContentStruct $value): ?ContentStruct {
                     if ($value === null) {
                         trigger_deprecation(
                             'ibexa/content-forms',

--- a/src/lib/Form/Type/Content/BaseContentType.php
+++ b/src/lib/Form/Type/Content/BaseContentType.php
@@ -74,9 +74,7 @@ class BaseContentType extends AbstractType
                     return $value;
                 }
 
-                return $options['userUpdateStruct']
-                    ?? $options['userCreateStruct']
-                    ?? $options['contentUpdateStruct']
+                return $options['contentUpdateStruct']
                     ?? $options['contentCreateStruct']
                     ?? null;
             })
@@ -91,8 +89,6 @@ class BaseContentType extends AbstractType
                     'null',
                     ContentCreateStruct::class,
                     ContentUpdateStruct::class,
-                    UserCreateStruct::class,
-                    UserUpdateStruct::class,
                 ],
             )
             ->setDeprecated(
@@ -106,6 +102,19 @@ class BaseContentType extends AbstractType
                 'ibexa/content-forms',
                 'v4.6.4',
                 'The option "%name%" is deprecated, use "struct" instead.'
+            )
+            ->setNormalizer('struct',
+                static function (Options $options, ?UserCreateStruct $value): ?UserCreateStruct {
+                    if ($value === null) {
+                        trigger_deprecation(
+                            'ibexa/content-forms',
+                            'v4.6',
+                            'The option "struct" with null value is deprecated and will be required in v5.0.'
+                        );
+                    }
+
+                    return $value;
+                }
             );
     }
 }

--- a/src/lib/Form/Type/User/UserCreateType.php
+++ b/src/lib/Form/Type/User/UserCreateType.php
@@ -47,13 +47,12 @@ class UserCreateType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setRequired('struct')
             ->setDefaults([
                 'data_class' => UserCreateData::class,
                 'intent' => 'create',
                 'translation_domain' => 'ibexa_content_forms_user',
             ])
-            ->setAllowedTypes('struct', UserCreateStruct::class);
+            ->setAllowedTypes('struct', ['null', UserCreateStruct::class]);
     }
 }
 

--- a/src/lib/Form/Type/User/UserUpdateType.php
+++ b/src/lib/Form/Type/User/UserUpdateType.php
@@ -47,7 +47,6 @@ class UserUpdateType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setRequired('struct')
             ->setDefaults([
                 'location' => null,
                 'content' => null,
@@ -55,7 +54,7 @@ class UserUpdateType extends AbstractType
                 'intent' => 'update',
                 'translation_domain' => 'ibexa_content_forms_user',
             ])
-            ->setAllowedTypes('struct', UserUpdateStruct::class);
+            ->setAllowedTypes('struct', ['null', UserUpdateStruct::class]);
     }
 }
 


### PR DESCRIPTION
| :ticket: Issue | IBX-7935 |
|----------------|-----------|

#### Related PRs: 
https://github.com/ibexa/corporate-account/pull/248 (but this should be tested alone, as it should fix CI in corporate-account)

#### Description:
As in baseContent, null, due to BC breaks should be also allowed for user related Types.

#### For QA:
Scenario from IBX-7935 should be retested.

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
