### PR TITLE
IBX-8704: Fixed missing field data on form re-render

### DIFF
--- a/src/lib/Data/Mapper/ContentUpdateMapper.php
+++ b/src/lib/Data/Mapper/ContentUpdateMapper.php
@@ -42,6 +42,9 @@ class ContentUpdateMapper implements FormDataMapperInterface
 
         foreach ($params['contentType']->fieldDefinitions as $fieldDef) {
             $isNonTranslatable = $fieldDef->isTranslatable === false;
+            if (!isset($fields[$fieldDef->identifier])) {
+                continue;
+            }
             $field = $fields[$fieldDef->identifier];
             $shouldUseCurrentFieldValue = $isNonTranslatable
                 && isset($mappedCurrentFields[$fieldDef->identifier])


### PR DESCRIPTION
| :ticket: Issue | IBX-8704 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This is an early fix for an issue that occurs when entering translation mode from an existing Content Object.

This allows the form to re-render even with incomplete data, but will require investigation about potential side-effects.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
