### PR TITLE
IBX-8711: Added setting default for struct option in ContentFieldType

### DIFF
--- a/src/lib/Form/Type/Content/ContentFieldType.php
+++ b/src/lib/Form/Type/Content/ContentFieldType.php
@@ -11,6 +11,7 @@ namespace Ibexa\ContentForms\Form\Type\Content;
 use Ibexa\ContentForms\FieldType\FieldTypeFormMapperDispatcherInterface;
 use Ibexa\Contracts\ContentForms\Data\Content\FieldData;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentStruct;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentUpdateStruct;
 use Ibexa\Contracts\Core\Repository\Values\User\UserCreateStruct;
 use Ibexa\Contracts\Core\Repository\Values\User\UserUpdateStruct;
@@ -20,6 +21,7 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ContentFieldType extends AbstractType
@@ -48,6 +50,21 @@ class ContentFieldType extends AbstractType
     {
         $resolver
             ->setRequired(['languageCode', 'mainLanguageCode', 'struct'])
+            ->setDefault('struct', static function (Options $options, ?ContentStruct $value) {
+                if ($value !== null) {
+                    return $value;
+                }
+
+                trigger_deprecation(
+                    'ibexa/content-forms',
+                    'v4.6',
+                    'The option "struct" with null value is deprecated and will be required in v5.0.'
+                );
+
+                return $options['contentUpdateStruct']
+                    ?? $options['contentCreateStruct']
+                    ?? null;
+            })
             ->setDefaults([
                 'content' => null,
                 'location' => null,

--- a/src/lib/Form/Type/Content/ContentFieldType.php
+++ b/src/lib/Form/Type/Content/ContentFieldType.php
@@ -50,7 +50,7 @@ class ContentFieldType extends AbstractType
     {
         $resolver
             ->setRequired(['languageCode', 'mainLanguageCode', 'struct'])
-            ->setDefault('struct', static function (Options $options, ?ContentStruct $value) {
+            ->setDefault('struct', static function (Options $options, ?ContentStruct $value): ?ContentStruct {
                 if ($value !== null) {
                     return $value;
                 }


### PR DESCRIPTION
| :ticket: Issue | IBX-8711 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/image-editor/pull/97 <- PR closed and instead created one in this repo, following @ViniTou suggestion.


#### Description:
Option "struct" is required in Ibexa\ContentForms\Form\Type\Content\ContentFieldType but has no default value.
This caused a throwing exception when editing the uploaded image in imageAssetField, when creating a form in Ibexa\Bundle\ImageEditor\Controller\ImageAssetController::buildImageFieldTypeForm(). 

Added setting a default value for this option. 

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
