### PR TITLE
IBX-6636: ezSelection default label 'ALL' is incorrect for NOT multiple choice setting

### DIFF
--- a/src/bundle/Resources/translations/ibexa_content_forms_fieldtype.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_content_forms_fieldtype.en.xliff
@@ -131,6 +131,11 @@
         <target state="new">Content location</target>
         <note>key: content_forms.relation.location_type.self</note>
       </trans-unit>
+      <trans-unit id="3753c5a7d2bddee50d6ffe5148884aa1ff5bfcb8" resname="content.field_type.ezselection.none">
+        <source>None</source>
+        <target state="new">None</target>
+        <note>key: content.field_type.ezselection.none</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/lib/FieldType/Mapper/SelectionFormMapper.php
+++ b/src/lib/FieldType/Mapper/SelectionFormMapper.php
@@ -11,10 +11,19 @@ namespace Ibexa\ContentForms\FieldType\Mapper;
 use Ibexa\ContentForms\Form\Type\FieldType\SelectionFieldType;
 use Ibexa\Contracts\ContentForms\Data\Content\FieldData;
 use Ibexa\Contracts\ContentForms\FieldType\FieldValueFormMapperInterface;
+use JMS\TranslationBundle\Annotation\Desc;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class SelectionFormMapper implements FieldValueFormMapperInterface
 {
+    private TranslatorInterface $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
     public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
     {
         $fieldDefinition = $data->fieldDefinition;
@@ -29,6 +38,13 @@ class SelectionFormMapper implements FieldValueFormMapperInterface
             $choices = $fieldDefinition->fieldSettings['multilingualOptions'][$fieldDefinition->mainLanguageCode];
         }
 
+        $placeholder = $this->translator->trans(
+            /** @Desc("None") */
+            'content.field_type.ezselection.none',
+            [],
+            'ibexa_content_forms_fieldtype',
+        );
+
         $fieldForm
             ->add(
                 $formConfig->getFormFactory()->createBuilder()
@@ -40,6 +56,7 @@ class SelectionFormMapper implements FieldValueFormMapperInterface
                                    'label' => $fieldDefinition->getName(),
                                    'multiple' => $fieldDefinition->fieldSettings['isMultiple'],
                                    'choices' => array_flip($choices),
+                                   'placeholder' => $placeholder,
                                ]
                            )
                            ->setAutoInitialize(false)


### PR DESCRIPTION
| :ticket: Issue | IBX-6636 |
|----------------|-----------|

The text `ALL` in the selection placeholder didn't make any sense. Changed it to `None`

![image](https://github.com/user-attachments/assets/9925fafb-c521-4a92-9f3d-69cf7d658381)

#### For QA:
- Create ContentType with ezselection ( multiselection *NOT* enabled ) with choices
  - BMW
  - Audi
  - Ford
- Create content with new ContentType and check the placeholder



<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
