### PR TITLE
IBX-9510: Fixed a fatal error when trying to create a new user

### DIFF
--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -88,29 +88,17 @@ services:
     # Controllers
     Ibexa\Bundle\ContentForms\Controller\ContentEditController:
         public: true
-        class: Ibexa\Bundle\ContentForms\Controller\ContentEditController
+        autowire: true
+        autoconfigure: true
         arguments:
-            - '@ibexa.api.service.content_type'
-            - '@ibexa.api.service.content'
-            - '@Ibexa\ContentForms\Form\ActionDispatcher\ContentDispatcher'
-        parent: Ibexa\Core\MVC\Symfony\Controller\Controller
-        tags:
-              - { name: controller.service_arguments }
+            $contentActionDispatcher: '@Ibexa\ContentForms\Form\ActionDispatcher\ContentDispatcher'
 
     Ibexa\Bundle\ContentForms\Controller\UserController:
+        autowire: true
+        autoconfigure: true
         arguments:
-            $contentTypeService: '@ibexa.api.service.content_type'
-            $userService: '@ibexa.api.service.user'
-            $locationService: '@ibexa.api.service.location'
-            $languageService: '@ibexa.api.service.language'
             $userActionDispatcher: '@Ibexa\ContentForms\Form\ActionDispatcher\UserDispatcher'
-            $permissionResolver: '@Ibexa\Contracts\Core\Repository\PermissionResolver'
-            $userLanguagePreferenceProvider: '@Ibexa\Core\MVC\Symfony\Locale\UserLanguagePreferenceProvider'
             $groupedContentFormFieldsProvider: '@Ibexa\ContentForms\Content\Form\Provider\GroupedContentFormFieldsProvider'
-            $contentService: '@ibexa.api.service.content'
-        parent: Ibexa\Core\MVC\Symfony\Controller\Controller
-        tags:
-              - { name: controller.service_arguments }
 
     ibexa_content_edit:
         alias: Ibexa\Bundle\ContentForms\Controller\ContentEditController


### PR DESCRIPTION
| :ticket: Issue | IBX-9510 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/content-forms/pull/78

#### Description:

This PR fixes a regression after Symfony 6 upgrade.

Controllers here were using an incorrect parent in their service definitions. 

I've changed those definitions to rely on autowiring and autoconfiguration instead. Otherwise instead of a proper service subscriber for Symfony `AbstractController`, the main container has been injected, in which services like `form.factory` were made private since Symfony 6.


#### For QA:

See steps from JIRA.


