### PR TITLE
IBX-9727: Added missing type hints

### DIFF
--- a/src/bundle/Controller/ContentEditController.php
+++ b/src/bundle/Controller/ContentEditController.php
@@ -23,14 +23,11 @@ use Symfony\Component\HttpFoundation\Request;
 
 class ContentEditController extends Controller
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\ContentService */
-    private $contentService;
+    private ContentService $contentService;
 
-    /** @var \Ibexa\ContentForms\Form\ActionDispatcher\ActionDispatcherInterface */
-    private $contentActionDispatcher;
+    private ActionDispatcherInterface $contentActionDispatcher;
 
     public function __construct(
         ContentTypeService $contentTypeService,

--- a/src/bundle/Controller/UserController.php
+++ b/src/bundle/Controller/UserController.php
@@ -30,29 +30,21 @@ use Symfony\Component\HttpFoundation\Request;
 
 class UserController extends Controller
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\UserService */
-    private $userService;
+    private UserService $userService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\LocationService */
-    private $locationService;
+    private LocationService $locationService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\LanguageService */
-    private $languageService;
+    private LanguageService $languageService;
 
-    /** @var \Ibexa\ContentForms\Form\ActionDispatcher\ActionDispatcherInterface */
-    private $userActionDispatcher;
+    private ActionDispatcherInterface $userActionDispatcher;
 
-    /** @var \Ibexa\Contracts\Core\Repository\PermissionResolver */
-    private $permissionResolver;
+    private PermissionResolver $permissionResolver;
 
-    /** @var \Ibexa\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface */
-    private $userLanguagePreferenceProvider;
+    private UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider;
 
-    /** @var \Ibexa\Contracts\ContentForms\Content\Form\Provider\GroupedContentFormFieldsProviderInterface */
-    private $groupedContentFormFieldsProvider;
+    private GroupedContentFormFieldsProviderInterface $groupedContentFormFieldsProvider;
 
     private ContentService $contentService;
 

--- a/src/bundle/DependencyInjection/Configuration/Parser/ContentEdit.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/ContentEdit.php
@@ -19,7 +19,7 @@ class ContentEdit extends AbstractParser
      *
      * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $nodeBuilder Node just under ezpublish.system.<siteaccess>
      */
-    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    public function addSemanticConfig(NodeBuilder $nodeBuilder): void
     {
         $nodeBuilder
             ->arrayNode('content_edit')
@@ -48,7 +48,7 @@ class ContentEdit extends AbstractParser
             ->end();
     }
 
-    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
     {
         if (empty($scopeSettings['content_edit'])) {
             return;

--- a/src/bundle/DependencyInjection/Configuration/Parser/UserEdit.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/UserEdit.php
@@ -19,7 +19,7 @@ class UserEdit extends AbstractParser
      *
      * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $nodeBuilder Node just under ezpublish.system.<siteaccess>
      */
-    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    public function addSemanticConfig(NodeBuilder $nodeBuilder): void
     {
         $nodeBuilder
             ->arrayNode('user_edit')
@@ -40,7 +40,7 @@ class UserEdit extends AbstractParser
             ->end();
     }
 
-    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
     {
         if (empty($scopeSettings['user_edit'])) {
             return;

--- a/src/lib/Behat/Context/ContentEditContext.php
+++ b/src/lib/Behat/Context/ContentEditContext.php
@@ -18,10 +18,8 @@ final class ContentEditContext extends MinkContext implements Context, SnippetAc
 {
     /**
      * Name of the content that was created using the edit form. Used to validate that the content was created.
-     *
-     * @var string
      */
-    private $createdContentName;
+    private ?string $createdContentName = null;
 
     /**
      * @var \Ibexa\ContentForms\Behat\Context\ContentTypeContext
@@ -30,13 +28,11 @@ final class ContentEditContext extends MinkContext implements Context, SnippetAc
 
     /**
      * Identifier of the FieldDefinition used to cover validation.
-     *
-     * @var string
      */
-    private static $constrainedFieldIdentifier = 'constrained_field';
+    private static string $constrainedFieldIdentifier = 'constrained_field';
 
     /** @BeforeScenario */
-    public function gatherContexts(BeforeScenarioScope $scope)
+    public function gatherContexts(BeforeScenarioScope $scope): void
     {
         $environment = $scope->getEnvironment();
 
@@ -47,7 +43,7 @@ final class ContentEditContext extends MinkContext implements Context, SnippetAc
      * @Then /^I should see a folder content edit form$/
      * @Then /^I should see a content edit form$/
      */
-    public function iShouldSeeAContentEditForm()
+    public function iShouldSeeAContentEditForm(): void
     {
         $this->assertSession()->elementExists('css', 'form[name=ezplatform_content_forms_content_edit]');
     }
@@ -55,7 +51,7 @@ final class ContentEditContext extends MinkContext implements Context, SnippetAc
     /**
      * @Then /^I am on the View of the Content that was published$/
      */
-    public function iAmOnTheViewOfTheContentThatWasPublished()
+    public function iAmOnTheViewOfTheContentThatWasPublished(): void
     {
         if (!isset($this->createdContentName)) {
             throw new \Exception('No created content name set');
@@ -68,7 +64,7 @@ final class ContentEditContext extends MinkContext implements Context, SnippetAc
     /**
      * @When /^I fill in the folder edit form$/
      */
-    public function iFillInTheFolderEditForm()
+    public function iFillInTheFolderEditForm(): void
     {
         // will only work for single value fields
         $this->createdContentName = 'Behat content edit @' . microtime(true);
@@ -78,7 +74,7 @@ final class ContentEditContext extends MinkContext implements Context, SnippetAc
     /**
      * @Given /^that I have permission to create folders$/
      */
-    public function thatIHavePermissionToCreateFolders()
+    public function thatIHavePermissionToCreateFolders(): void
     {
         $this->visit('/login');
         $this->fillField('_username', 'admin');
@@ -89,7 +85,7 @@ final class ContentEditContext extends MinkContext implements Context, SnippetAc
     /**
      * @Given /^that I have permission to create content of this type$/
      */
-    public function thatIHavePermissionToCreateContentOfThisType()
+    public function thatIHavePermissionToCreateContentOfThisType(): void
     {
         $this->thatIHavePermissionToCreateFolders();
     }
@@ -97,7 +93,7 @@ final class ContentEditContext extends MinkContext implements Context, SnippetAc
     /**
      * @When /^I go to the content creation page for this type$/
      */
-    public function iGoToTheContentCreationPageForThisType()
+    public function iGoToTheContentCreationPageForThisType(): void
     {
         $uri = sprintf(
             '/content/create/nodraft/%s/eng-GB/2',
@@ -110,7 +106,7 @@ final class ContentEditContext extends MinkContext implements Context, SnippetAc
     /**
      * @Given /^I fill in the constrained field with an invalid value$/
      */
-    public function iFillInTheConstrainedFieldWithAnInvalidValue()
+    public function iFillInTheConstrainedFieldWithAnInvalidValue(): void
     {
         $this->fillField(
             sprintf(
@@ -132,7 +128,7 @@ final class ContentEditContext extends MinkContext implements Context, SnippetAc
     /**
      * @Then /^I am shown the content creation form$/
      */
-    public function iAmShownTheContentCreationForm()
+    public function iAmShownTheContentCreationForm(): void
     {
         $uri = sprintf(
             '/content/create/nodraft/%s/eng-GB/2',
@@ -151,7 +147,7 @@ final class ContentEditContext extends MinkContext implements Context, SnippetAc
     /**
      * @Given /^there is a relevant error message linked to the invalid field$/
      */
-    public function thereIsARelevantErrorMessageLinkedToTheInvalidField()
+    public function thereIsARelevantErrorMessageLinkedToTheInvalidField(): void
     {
         $selector = sprintf(
             '#ezplatform_content_forms_content_edit_fieldsData_%s div ul li',
@@ -165,7 +161,7 @@ final class ContentEditContext extends MinkContext implements Context, SnippetAc
     /**
      * @Given /^that there is a content type with any kind of constraints on a Field Definition$/
      */
-    public function thereIsAContentTypeWithAnyKindOfConstraintsOnAFieldDefinition()
+    public function thereIsAContentTypeWithAnyKindOfConstraintsOnAFieldDefinition(): void
     {
         $contentTypeCreateStruct = $this->contentTypeContext->newContentTypeCreateStruct();
 
@@ -188,7 +184,7 @@ final class ContentEditContext extends MinkContext implements Context, SnippetAc
     /**
      * @When /^a content creation form is displayed$/
      */
-    public function aContentCreationFormIsDisplayed()
+    public function aContentCreationFormIsDisplayed(): void
     {
         $this->visit('/content/create/nodraft/folder/eng-GB/2');
     }

--- a/src/lib/Behat/Context/ContentTypeContext.php
+++ b/src/lib/Behat/Context/ContentTypeContext.php
@@ -22,8 +22,7 @@ use PHPUnit\Framework\Assert as Assertion;
 
 final class ContentTypeContext extends RawMinkContext implements Context, SnippetAcceptingContext
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
     /**
      * Current content type within this context.
@@ -32,13 +31,12 @@ final class ContentTypeContext extends RawMinkContext implements Context, Snippe
      */
     private $currentContentType;
 
-    /** @var \Ibexa\Contracts\Core\Repository\PermissionResolver */
-    private $permissionResolver;
+    private PermissionResolver $permissionResolver;
 
     /**
      * Default Administrator user id.
      */
-    private $adminUserId = 14;
+    private int $adminUserId = 14;
 
     public function __construct(PermissionResolver $permissionResolver, ContentTypeService $contentTypeService)
     {
@@ -50,7 +48,7 @@ final class ContentTypeContext extends RawMinkContext implements Context, Snippe
     /**
      * @Given /^there is a content type "([^"]*)" with the id "([^"]*)"$/
      */
-    public function thereIsAContentTypeWithId($contentTypeIdentifier, $id)
+    public function thereIsAContentTypeWithId(string $contentTypeIdentifier, $id): void
     {
         try {
             $contentType = $this->contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
@@ -63,7 +61,7 @@ final class ContentTypeContext extends RawMinkContext implements Context, Snippe
     /**
      * @Given I remove :fieldIdentifier field from :contentTypeIdentifier content type
      */
-    public function iRemoveFieldFromContentType($fieldIdentifier, $contentTypeIdentifier)
+    public function iRemoveFieldFromContentType($fieldIdentifier, string $contentTypeIdentifier): void
     {
         $contentType = $this->contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
         $contentTypeDraft = $this->contentTypeService->createContentTypeDraft($contentType);
@@ -74,7 +72,7 @@ final class ContentTypeContext extends RawMinkContext implements Context, Snippe
         $this->contentTypeService->publishContentTypeDraft($contentTypeDraft);
     }
 
-    public function addFieldsTo($contentTypeIdentifier, array $fieldDefinitions)
+    public function addFieldsTo(string $contentTypeIdentifier, array $fieldDefinitions): void
     {
         $contentType = $this->contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
         $contentTypeDraft = $this->contentTypeService->createContentTypeDraft($contentType);
@@ -100,7 +98,7 @@ final class ContentTypeContext extends RawMinkContext implements Context, Snippe
         return $this->currentContentType;
     }
 
-    public function createContentType(ContentTypeCreateStruct $struct)
+    public function createContentType(ContentTypeCreateStruct $struct): void
     {
         if (!isset($struct->mainLanguageCode)) {
             $struct->mainLanguageCode = 'eng-GB';
@@ -125,14 +123,14 @@ final class ContentTypeContext extends RawMinkContext implements Context, Snippe
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeCreateStruct
      */
-    public function newContentTypeCreateStruct($identifier = null)
+    public function newContentTypeCreateStruct($identifier = null): ContentTypeCreateStruct
     {
         return $this->contentTypeService->newContentTypeCreateStruct(
             $identifier ?: $identifier = str_replace('.', '', uniqid('content_type_', true))
         );
     }
 
-    public function updateFieldDefinition($identifier, FieldDefinitionUpdateStruct $fieldDefinitionUpdateStruct)
+    public function updateFieldDefinition($identifier, FieldDefinitionUpdateStruct $fieldDefinitionUpdateStruct): void
     {
         $contentTypeDraft = $this->contentTypeService->createContentTypeDraft($this->currentContentType);
 

--- a/src/lib/Behat/Context/FieldTypeFormContext.php
+++ b/src/lib/Behat/Context/FieldTypeFormContext.php
@@ -18,9 +18,9 @@ use PHPUnit\Framework\Assert as Assertion;
 
 final class FieldTypeFormContext extends RawMinkContext implements SnippetAcceptingContext
 {
-    private static $fieldIdentifier = 'field';
+    private static string $fieldIdentifier = 'field';
 
-    private static $fieldTypeIdentifierMap = [
+    private static array $fieldTypeIdentifierMap = [
         'user' => 'ezuser',
         'textline' => 'ezstring',
         'selection' => 'ezselection',
@@ -30,7 +30,7 @@ final class FieldTypeFormContext extends RawMinkContext implements SnippetAccept
     private $contentTypeContext;
 
     /** @BeforeScenario */
-    public function gatherContexts(BeforeScenarioScope $scope)
+    public function gatherContexts(BeforeScenarioScope $scope): void
     {
         $environment = $scope->getEnvironment();
         $this->contentTypeContext = $environment->getContext(ContentTypeContext::class);
@@ -40,7 +40,7 @@ final class FieldTypeFormContext extends RawMinkContext implements SnippetAccept
      * @Given a content type with a(n) :fieldTypeIdentifier field definition
      * @Given a content type :contentTypeName with a(n) :fieldTypeIdentifier field definition
      */
-    public function aContentTypeWithAGivenFieldDefinition($fieldTypeIdentifier, $contentTypeName = null)
+    public function aContentTypeWithAGivenFieldDefinition($fieldTypeIdentifier, $contentTypeName = null): void
     {
         if (isset(self::$fieldTypeIdentifierMap[$fieldTypeIdentifier])) {
             $fieldTypeIdentifier = self::$fieldTypeIdentifierMap[$fieldTypeIdentifier];
@@ -80,7 +80,7 @@ final class FieldTypeFormContext extends RawMinkContext implements SnippetAccept
     /**
      * @When /^I view the edit form for this field$/
      */
-    public function iEditOrCreateContentOfThisType()
+    public function iEditOrCreateContentOfThisType(): void
     {
         $this->visitPath(
             sprintf(
@@ -93,7 +93,7 @@ final class FieldTypeFormContext extends RawMinkContext implements SnippetAccept
     /**
      * @When /^I view the edit user form for this field$/
      */
-    public function iEditOrCreateContentOfUserType()
+    public function iEditOrCreateContentOfUserType(): void
     {
         $this->visitPath(
             sprintf(
@@ -106,7 +106,7 @@ final class FieldTypeFormContext extends RawMinkContext implements SnippetAccept
     /**
      * @Then the edit form should contain an identifiable widget for :fieldTypeIdentifier field definition
      */
-    public function theEditFormShouldContainAFieldsetNamedAfterTheFieldDefinition($fieldTypeIdentifier)
+    public function theEditFormShouldContainAFieldsetNamedAfterTheFieldDefinition(string $fieldTypeIdentifier): void
     {
         $this->assertSession()->elementTextContains(
             'css',
@@ -118,7 +118,7 @@ final class FieldTypeFormContext extends RawMinkContext implements SnippetAccept
     /**
      * @Given it should contain a :type input field
      */
-    public function itShouldContainAGivenTypeInputField($inputType)
+    public function itShouldContainAGivenTypeInputField($inputType): void
     {
         $this->assertSession()->elementExists(
             'css',
@@ -134,7 +134,7 @@ final class FieldTypeFormContext extends RawMinkContext implements SnippetAccept
     /**
      * @Given /^it should contain the following set of labels, and input fields of the following types:$/
      */
-    public function itShouldContainTheFollowingSetOfLabelsAndInputFieldsTypes(TableNode $table)
+    public function itShouldContainTheFollowingSetOfLabelsAndInputFieldsTypes(TableNode $table): void
     {
         $inputNodeElements = $this->getSession()->getPage()->findAll(
             'css',
@@ -162,7 +162,7 @@ final class FieldTypeFormContext extends RawMinkContext implements SnippetAccept
      * @Given /^the field definition is required$/
      * @Given /^the field definition is marked as required$/
      */
-    public function theFieldDefinitionIsMarkedAsRequired()
+    public function theFieldDefinitionIsMarkedAsRequired(): void
     {
         $this->contentTypeContext->updateFieldDefinition(
             self::$fieldIdentifier,
@@ -173,7 +173,7 @@ final class FieldTypeFormContext extends RawMinkContext implements SnippetAccept
     /**
      * @Then the value input fields for :fieldIdentifier field should be flagged as required
      */
-    public function theInputFieldsShouldBeFlaggedAsRequired(string $fieldTypeIdentifier)
+    public function theInputFieldsShouldBeFlaggedAsRequired(string $fieldTypeIdentifier): void
     {
         $inputNodeElements = $this->getSession()->getPage()->findAll(
             'css',
@@ -212,7 +212,7 @@ final class FieldTypeFormContext extends RawMinkContext implements SnippetAccept
      * @param $option string The field definition option
      * @param $value mixed The option value
      */
-    public function setFieldDefinitionOption($option, $value)
+    public function setFieldDefinitionOption($option, $value): void
     {
         $this->contentTypeContext->updateFieldDefinition(
             self::$fieldIdentifier,

--- a/src/lib/Behat/Context/PagelayoutContext.php
+++ b/src/lib/Behat/Context/PagelayoutContext.php
@@ -19,10 +19,7 @@ class PagelayoutContext extends RawMinkContext implements Context, SnippetAccept
     /** @var string Regex matching the way the Twig template name is inserted in debug mode */
     public const TWIG_DEBUG_STOP_REGEX = '<!-- STOP .*%s.* -->';
 
-    /**
-     * @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface
-     */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
     public function __construct(ConfigResolverInterface $configResolver)
     {
@@ -32,7 +29,7 @@ class PagelayoutContext extends RawMinkContext implements Context, SnippetAccept
     /**
      * @Given /^a pagelayout is configured$/
      */
-    public function aPagelayoutIsConfigured()
+    public function aPagelayoutIsConfigured(): void
     {
         Assertion::assertTrue($this->configResolver->hasParameter('page_layout'));
     }
@@ -40,7 +37,7 @@ class PagelayoutContext extends RawMinkContext implements Context, SnippetAccept
     /**
      * @Then /^it is rendered using the configured pagelayout$/
      */
-    public function itIsRenderedUsingTheConfiguredPagelayout()
+    public function itIsRenderedUsingTheConfiguredPagelayout(): void
     {
         $pageLayout = $this->getPageLayout();
 

--- a/src/lib/Behat/Context/SelectionFieldTypeFormContext.php
+++ b/src/lib/Behat/Context/SelectionFieldTypeFormContext.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\Assert as Assertion;
 
 final class SelectionFieldTypeFormContext extends RawMinkContext implements SnippetAcceptingContext
 {
-    private static $fieldIdentifier = 'field';
+    private static string $fieldIdentifier = 'field';
 
     /**
      * @var \Ibexa\ContentForms\Behat\Context\FieldTypeFormContext
@@ -23,7 +23,7 @@ final class SelectionFieldTypeFormContext extends RawMinkContext implements Snip
     private $fieldTypeFormContext;
 
     /** @BeforeScenario */
-    public function gatherContexts(BeforeScenarioScope $scope)
+    public function gatherContexts(BeforeScenarioScope $scope): void
     {
         $this->fieldTypeFormContext = $scope->getEnvironment()->getContext(FieldTypeFormContext::class);
     }
@@ -31,7 +31,7 @@ final class SelectionFieldTypeFormContext extends RawMinkContext implements Snip
     /**
      * @Given /^the field definition is set to single choice$/
      */
-    public function setFieldDefinitionToSingleChoice()
+    public function setFieldDefinitionToSingleChoice(): void
     {
         $this->fieldTypeFormContext->setFieldDefinitionOption('isMultiple', false);
     }
@@ -39,7 +39,7 @@ final class SelectionFieldTypeFormContext extends RawMinkContext implements Snip
     /**
      * @Given /^the field definition is set to multiple choice$/
      */
-    public function setFieldDefinitionToMultipleChoice()
+    public function setFieldDefinitionToMultipleChoice(): void
     {
         $this->fieldTypeFormContext->setFieldDefinitionOption('isMultiple', true);
     }
@@ -47,7 +47,7 @@ final class SelectionFieldTypeFormContext extends RawMinkContext implements Snip
     /**
      * @Then it should contain a select field
      */
-    public function itShouldContainASelectField()
+    public function itShouldContainASelectField(): void
     {
         $this->assertSession()->elementExists(
             'css',
@@ -62,7 +62,7 @@ final class SelectionFieldTypeFormContext extends RawMinkContext implements Snip
     /**
      * @Then the select field should be flagged as required
      */
-    public function theSelectFieldShouldBeFlaggedAsRequired()
+    public function theSelectFieldShouldBeFlaggedAsRequired(): void
     {
         $nodeElements = $this->getSession()->getPage()->findAll(
             'css',
@@ -87,7 +87,7 @@ final class SelectionFieldTypeFormContext extends RawMinkContext implements Snip
     /**
      * @Then the input is a single selection dropdown
      */
-    public function theInputIsASingleSelectionDropdown()
+    public function theInputIsASingleSelectionDropdown(): void
     {
         $selector = sprintf(
             'select[name="ezplatform_content_forms_content_edit[fieldsData][%s][value]"]',
@@ -101,7 +101,7 @@ final class SelectionFieldTypeFormContext extends RawMinkContext implements Snip
     /**
      * @Then the input is a multiple selection dropdown
      */
-    public function theInputIsAMultipleSelectionDropdown()
+    public function theInputIsAMultipleSelectionDropdown(): void
     {
         $selector = sprintf(
             'select[name="ezplatform_content_forms_content_edit[fieldsData][%s][value][]"][multiple=multiple]',

--- a/src/lib/Behat/Context/UserRegistrationContext.php
+++ b/src/lib/Behat/Context/UserRegistrationContext.php
@@ -35,13 +35,13 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
      */
     public const TWIG_DEBUG_STOP_REGEX = '<!-- STOP .*%s.* -->';
 
-    private static $password = 'PassWord42';
+    private static string $password = 'PassWord42';
 
-    private static $language = 'eng-GB';
+    private static string $language = 'eng-GB';
 
-    private static $groupId = 4;
+    private static int $groupId = 4;
 
-    private $registrationUsername;
+    private ?string $registrationUsername = null;
 
     /**
      * Used to cover registration group customization.
@@ -58,19 +58,15 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     /**
      * Default Administrator user id.
      */
-    private $adminUserId = 14;
+    private int $adminUserId = 14;
 
-    /** @var \Ibexa\Contracts\Core\Repository\PermissionResolver */
-    private $permissionResolver;
+    private PermissionResolver $permissionResolver;
 
-    /** @var \Ibexa\Contracts\Core\Repository\RoleService */
-    private $roleService;
+    private RoleService $roleService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\UserService */
-    private $userService;
+    private UserService $userService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
     public function __construct(
         PermissionResolver $permissionResolver,
@@ -86,7 +82,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     }
 
     /** @BeforeScenario */
-    public function gatherContexts(BeforeScenarioScope $scope)
+    public function gatherContexts(BeforeScenarioScope $scope): void
     {
         $this->yamlConfigurationContext = $scope->getEnvironment()->getContext(YamlConfigurationContext::class);
     }
@@ -94,7 +90,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     /**
      * @Given /^I do not have the user\/register policy$/
      */
-    public function loginAsUserWithoutRegisterPolicy()
+    public function loginAsUserWithoutRegisterPolicy(): void
     {
         $role = $this->createRegistrationRole(false);
         $user = $this->createUserWithRole($role);
@@ -104,7 +100,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     /**
      * @Given /^I do have the user\/register policy$/
      */
-    public function loginAsUserWithUserRegisterPolicy()
+    public function loginAsUserWithUserRegisterPolicy(): void
     {
         $role = $this->createRegistrationRole(true);
         $user = $this->createUserWithRole($role);
@@ -145,7 +141,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\User\Role
      */
-    private function createRegistrationRole($withUserRegisterPolicy = true)
+    private function createRegistrationRole(bool $withUserRegisterPolicy = true): Role
     {
         $roleIdentifier = uniqid(
             'anonymous_role_' . ($withUserRegisterPolicy ? 'with' : 'without') . '_register',
@@ -174,7 +170,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     /**
      * @Then /^I see an error message saying that I can not register$/
      */
-    public function iSeeAnErrorMessageSayingThatICanNotRegister()
+    public function iSeeAnErrorMessageSayingThatICanNotRegister(): void
     {
         $this->assertSession()->pageTextContains('You are not allowed to register a new account');
     }
@@ -184,7 +180,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
      *
      * @throws \Behat\Mink\Exception\ElementNotFoundException
      */
-    private function loginAs(User $user)
+    private function loginAs(User $user): void
     {
         $this->visitPath('/login');
         $page = $this->getSession()->getPage();
@@ -197,7 +193,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     /**
      * @Then /^I can see the registration form$/
      */
-    public function iCanSeeTheRegistrationForm()
+    public function iCanSeeTheRegistrationForm(): void
     {
         $this->assertSession()->pageTextNotContains('You are not allowed to register a new account');
         $this->assertSession()->elementExists('css', 'form[name=ezplatform_content_forms_user_register]');
@@ -206,7 +202,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     /**
      * @Given /^it matches the structure of the configured registration user content type$/
      */
-    public function itMatchesTheStructureOfTheConfiguredRegistrationUserContentType()
+    public function itMatchesTheStructureOfTheConfiguredRegistrationUserContentType(): void
     {
         $userContentType = $this->contentTypeService->loadContentTypeByIdentifier('user');
         foreach ($userContentType->getFieldDefinitions() as $fieldDefinition) {
@@ -224,7 +220,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     /**
      * @Given /^it has a register button$/
      */
-    public function itHasARegisterButton()
+    public function itHasARegisterButton(): void
     {
         $this->assertSession()->elementExists(
             'css',
@@ -235,7 +231,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     /**
      * @When /^I fill in the form with valid values$/
      */
-    public function iFillInTheFormWithValidValues()
+    public function iFillInTheFormWithValidValues(): void
     {
         $page = $this->getSession()->getPage();
 
@@ -252,7 +248,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     /**
      * @When /^I click on the register button$/
      */
-    public function iClickOnTheRegisterButton()
+    public function iClickOnTheRegisterButton(): void
     {
         $this->getSession()->getPage()->pressButton('ezplatform_content_forms_user_register[register]');
         $this->assertSession()->statusCodeEquals(200);
@@ -261,7 +257,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     /**
      * @Then /^I am on the registration confirmation page$/
      */
-    public function iAmOnTheRegistrationConfirmationPage()
+    public function iAmOnTheRegistrationConfirmationPage(): void
     {
         $this->assertSession()->addressEquals('/register-confirm');
     }
@@ -269,7 +265,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     /**
      * @Given /^I see a registration confirmation message$/
      */
-    public function iSeeARegistrationConfirmationMessage()
+    public function iSeeARegistrationConfirmationMessage(): void
     {
         $this->assertSession()->pageTextContains('Your account has been created');
     }
@@ -277,7 +273,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     /**
      * @Given /^the user account has been created$/
      */
-    public function theUserAccountHasBeenCreated()
+    public function theUserAccountHasBeenCreated(): void
     {
         $this->userService->loadUserByLogin($this->registrationUsername);
     }
@@ -285,7 +281,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     /**
      * @Given a User Group :userGroupName
      */
-    public function createUserGroup(string $userGroupName)
+    public function createUserGroup(string $userGroupName): void
     {
         $groupCreateStruct = $this->userService->newUserGroupCreateStruct(self::$language);
         $groupCreateStruct->setField('name', $userGroupName);
@@ -298,7 +294,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     /**
      * @Given /^the following user registration group configuration:$/
      */
-    public function addUserRegistrationConfiguration(PyStringNode $extraConfigurationString)
+    public function addUserRegistrationConfiguration(PyStringNode $extraConfigurationString): void
     {
         $extraConfigurationString = str_replace(
             '<userGroupContentId>',
@@ -312,7 +308,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     /**
      * @When /^I register a user account$/
      */
-    public function iRegisterAUserAccount()
+    public function iRegisterAUserAccount(): void
     {
         $this->loginAsUserWithUserRegisterPolicy();
         $this->visitPath('/register');
@@ -326,7 +322,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     /**
      * @Then /^the user is created in :userGroupName user group$/
      */
-    public function theUserIsCreatedInThisUserGroup(string $userGroupName)
+    public function theUserIsCreatedInThisUserGroup(string $userGroupName): void
     {
         $user = $this->userService->loadUserByLogin($this->registrationUsername);
         $userGroups = $this->userService->loadUserGroupsOfUser($user);
@@ -340,7 +336,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     /**
      * @Given /^the following user registration templates configuration:$/
      */
-    public function addRegistrationTemplatesConfiguration(PyStringNode $pyStringNode)
+    public function addRegistrationTemplatesConfiguration(PyStringNode $pyStringNode): void
     {
         $this->yamlConfigurationContext->addConfiguration(Yaml::parse((string) $pyStringNode));
     }
@@ -348,7 +344,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     /**
      * @Given /^the following template in "([^"]*)":$/
      */
-    public function createTemplateAt($path, PyStringNode $contents)
+    public function createTemplateAt(string $path, PyStringNode $contents): void
     {
         $fs = new Filesystem();
         $fs->mkdir(dirname($path));
@@ -364,7 +360,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
      *        If relative to app/Resources/views (example: user/register.html.twig),
      *        the path is checked with the :path:file.html.twig syntax as well.
      */
-    public function thePageIsRenderedUsingTheTemplateConfiguredIn($template)
+    public function thePageIsRenderedUsingTheTemplateConfiguredIn($template): void
     {
         $html = $this->getSession()->getPage()->getOuterHtml();
         $searchedPattern = sprintf(self::TWIG_DEBUG_STOP_REGEX, preg_quote($template, null));

--- a/src/lib/Content/View/Builder/AbstractContentViewBuilder.php
+++ b/src/lib/Content/View/Builder/AbstractContentViewBuilder.php
@@ -25,29 +25,21 @@ use Ibexa\Core\MVC\Symfony\View\ParametersInjector;
  */
 abstract class AbstractContentViewBuilder
 {
-    /** @var \Ibexa\Contracts\Core\Repository\Repository */
-    protected $repository;
+    protected Repository $repository;
 
-    /** @var \Ibexa\Core\MVC\Symfony\View\Configurator */
-    protected $viewConfigurator;
+    protected Configurator $viewConfigurator;
 
-    /** @var \Ibexa\Core\MVC\Symfony\View\ParametersInjector */
-    protected $viewParametersInjector;
+    protected ParametersInjector $viewParametersInjector;
 
-    /** @var \Ibexa\ContentForms\Form\ActionDispatcher\ActionDispatcherInterface */
-    protected $contentActionDispatcher;
+    protected ActionDispatcherInterface $contentActionDispatcher;
 
-    /** @var \Ibexa\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface */
-    protected $languagePreferenceProvider;
+    protected UserLanguagePreferenceProviderInterface $languagePreferenceProvider;
 
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    protected $configResolver;
+    protected ConfigResolverInterface $configResolver;
 
-    /** @var \Ibexa\Contracts\ContentForms\Content\Form\Provider\GroupedContentFormFieldsProviderInterface */
-    protected $groupedContentFormFieldsProvider;
+    protected GroupedContentFormFieldsProviderInterface $groupedContentFormFieldsProvider;
 
-    /** @var \Ibexa\Contracts\Core\Repository\ContentService */
-    protected $contentService;
+    protected ContentService $contentService;
 
     public function __construct(
         Repository $repository,

--- a/src/lib/Content/View/ContentCreateSuccessView.php
+++ b/src/lib/Content/View/ContentCreateSuccessView.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpKernel\Controller\ControllerReference;
 class ContentCreateSuccessView extends BaseView implements LocationValueView
 {
     /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Location|null */
-    private $location;
+    private ?Location $location = null;
 
     /**
      * @param \Symfony\Component\HttpFoundation\Response $response

--- a/src/lib/Content/View/ContentCreateView.php
+++ b/src/lib/Content/View/ContentCreateView.php
@@ -18,21 +18,21 @@ use Symfony\Component\Form\FormInterface;
 class ContentCreateView extends BaseView implements LocationValueView, ContentTypeValueView
 {
     /** @var \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType */
-    private $contentType;
+    private ContentType $contentType;
 
     /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Location */
-    private $location;
+    private Location $location;
 
     /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Language */
-    private $language;
+    private Language $language;
 
     /** @var \Symfony\Component\Form\FormInterface */
-    private $form;
+    private FormInterface $form;
 
     /**
      * @param \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType $contentType
      */
-    public function setContentType(ContentType $contentType)
+    public function setContentType(ContentType $contentType): void
     {
         $this->contentType = $contentType;
     }
@@ -48,7 +48,7 @@ class ContentCreateView extends BaseView implements LocationValueView, ContentTy
     /**
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\Location $location
      */
-    public function setLocation(Location $location)
+    public function setLocation(Location $location): void
     {
         $this->location = $location;
     }
@@ -72,7 +72,7 @@ class ContentCreateView extends BaseView implements LocationValueView, ContentTy
     /**
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\Language $language
      */
-    public function setLanguage(Language $language)
+    public function setLanguage(Language $language): void
     {
         $this->language = $language;
     }
@@ -88,7 +88,7 @@ class ContentCreateView extends BaseView implements LocationValueView, ContentTy
     /**
      * @param \Symfony\Component\Form\FormInterface $form
      */
-    public function setForm(FormInterface $form)
+    public function setForm(FormInterface $form): void
     {
         $this->form = $form;
     }

--- a/src/lib/Content/View/ContentEditSuccessView.php
+++ b/src/lib/Content/View/ContentEditSuccessView.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpKernel\Controller\ControllerReference;
 class ContentEditSuccessView extends BaseView implements LocationValueView
 {
     /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Location|null */
-    private $location;
+    private ?Location $location = null;
 
     /**
      * @param \Symfony\Component\HttpFoundation\Response $response

--- a/src/lib/Content/View/ContentEditView.php
+++ b/src/lib/Content/View/ContentEditView.php
@@ -19,21 +19,21 @@ use Symfony\Component\Form\FormInterface;
 class ContentEditView extends BaseView implements ContentValueView, LocationValueView
 {
     /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Content */
-    private $content;
+    private Content $content;
 
     /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Location|null */
-    private $location;
+    private ?Location $location = null;
 
     /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Language */
-    private $language;
+    private Language $language;
 
     /** @var \Symfony\Component\Form\FormInterface */
-    private $form;
+    private FormInterface $form;
 
     /**
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content $content
      */
-    public function setContent(Content $content)
+    public function setContent(Content $content): void
     {
         $this->content = $content;
     }
@@ -51,7 +51,7 @@ class ContentEditView extends BaseView implements ContentValueView, LocationValu
     /**
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\Location|null $location
      */
-    public function setLocation(?Location $location)
+    public function setLocation(?Location $location): void
     {
         $this->location = $location;
     }
@@ -75,7 +75,7 @@ class ContentEditView extends BaseView implements ContentValueView, LocationValu
     /**
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\Language $language
      */
-    public function setLanguage(Language $language)
+    public function setLanguage(Language $language): void
     {
         $this->language = $language;
     }
@@ -91,7 +91,7 @@ class ContentEditView extends BaseView implements ContentValueView, LocationValu
     /**
      * @param \Symfony\Component\Form\FormInterface $form
      */
-    public function setForm(FormInterface $form)
+    public function setForm(FormInterface $form): void
     {
         $this->form = $form;
     }

--- a/src/lib/Content/View/Filter/ContentCreateViewFilter.php
+++ b/src/lib/Content/View/Filter/ContentCreateViewFilter.php
@@ -24,17 +24,13 @@ use Symfony\Component\Form\FormInterface;
 
 class ContentCreateViewFilter implements EventSubscriberInterface
 {
-    /** @var \Ibexa\Contracts\Core\Repository\LocationService */
-    private $locationService;
+    private LocationService $locationService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
-    /** @var \Symfony\Component\Form\FormFactoryInterface */
-    private $formFactory;
+    private FormFactoryInterface $formFactory;
 
-    /** @var \Ibexa\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface */
-    private $languagePreferenceProvider;
+    private UserLanguagePreferenceProviderInterface $languagePreferenceProvider;
 
     /**
      * @param \Ibexa\Contracts\Core\Repository\LocationService $locationService
@@ -66,7 +62,7 @@ class ContentCreateViewFilter implements EventSubscriberInterface
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
      */
-    public function handleContentCreateForm(FilterViewBuilderParametersEvent $event)
+    public function handleContentCreateForm(FilterViewBuilderParametersEvent $event): void
     {
         if ('ibexa_content_edit::createWithoutDraftAction' !== $event->getParameters()->get('_controller')) {
             return;

--- a/src/lib/Content/View/Filter/ContentEditViewFilter.php
+++ b/src/lib/Content/View/Filter/ContentEditViewFilter.php
@@ -27,17 +27,13 @@ use Symfony\Component\Form\FormInterface;
 
 class ContentEditViewFilter implements EventSubscriberInterface
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ContentService */
-    private $contentService;
+    private ContentService $contentService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
-    /** @var \Symfony\Component\Form\FormFactoryInterface */
-    private $formFactory;
+    private FormFactoryInterface $formFactory;
 
-    /** @var \Ibexa\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface */
-    private $languagePreferenceProvider;
+    private UserLanguagePreferenceProviderInterface $languagePreferenceProvider;
 
     private LocationService $locationService;
 
@@ -73,7 +69,7 @@ class ContentEditViewFilter implements EventSubscriberInterface
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
      */
-    public function handleContentEditForm(FilterViewBuilderParametersEvent $event)
+    public function handleContentEditForm(FilterViewBuilderParametersEvent $event): void
     {
         if ('ibexa_content_edit::editVersionDraftAction' !== $event->getParameters()->get('_controller')) {
             return;

--- a/src/lib/Content/View/Provider/ContentCreateView/Configured.php
+++ b/src/lib/Content/View/Provider/ContentCreateView/Configured.php
@@ -19,10 +19,7 @@ use Symfony\Component\HttpKernel\Controller\ControllerReference;
  */
 class Configured implements ViewProvider
 {
-    /**
-     * @var \Ibexa\Core\MVC\Symfony\Matcher\MatcherFactoryInterface
-     */
-    protected $matcherFactory;
+    protected MatcherFactoryInterface $matcherFactory;
 
     /**
      * @param \Ibexa\Core\MVC\Symfony\Matcher\MatcherFactoryInterface $matcherFactory

--- a/src/lib/Content/View/Provider/ContentEditView/Configured.php
+++ b/src/lib/Content/View/Provider/ContentEditView/Configured.php
@@ -19,10 +19,7 @@ use Symfony\Component\HttpKernel\Controller\ControllerReference;
  */
 class Configured implements ViewProvider
 {
-    /**
-     * @var \Ibexa\Core\MVC\Symfony\Matcher\MatcherFactoryInterface
-     */
-    protected $matcherFactory;
+    protected MatcherFactoryInterface $matcherFactory;
 
     /**
      * @param \Ibexa\Core\MVC\Symfony\Matcher\MatcherFactoryInterface $matcherFactory

--- a/src/lib/Data/Content/ContentCreateData.php
+++ b/src/lib/Data/Content/ContentCreateData.php
@@ -22,9 +22,9 @@ class ContentCreateData extends ContentCreateStruct implements NewnessCheckable
     /**
      * @var \Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct[]
      */
-    private $locationStructs;
+    private ?array $locationStructs = null;
 
-    public function isNew()
+    public function isNew(): bool
     {
         return true;
     }
@@ -43,7 +43,7 @@ class ContentCreateData extends ContentCreateStruct implements NewnessCheckable
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct $locationStruct
      */
-    public function addLocationStruct(LocationCreateStruct $locationStruct)
+    public function addLocationStruct(LocationCreateStruct $locationStruct): void
     {
         $this->locationStructs[] = $locationStruct;
     }

--- a/src/lib/Data/Content/ContentData.php
+++ b/src/lib/Data/Content/ContentData.php
@@ -17,7 +17,7 @@ trait ContentData
      */
     protected $fieldsData;
 
-    public function addFieldData(FieldData $fieldData)
+    public function addFieldData(FieldData $fieldData): void
     {
         $this->fieldsData[$fieldData->fieldDefinition->identifier] = $fieldData;
     }

--- a/src/lib/Data/Content/ContentUpdateData.php
+++ b/src/lib/Data/Content/ContentUpdateData.php
@@ -21,7 +21,7 @@ class ContentUpdateData extends ContentUpdateStruct implements NewnessCheckable
 
     protected $contentDraft;
 
-    public function isNew()
+    public function isNew(): bool
     {
         return false;
     }

--- a/src/lib/Data/Mapper/ContentCreateMapper.php
+++ b/src/lib/Data/Mapper/ContentCreateMapper.php
@@ -27,7 +27,7 @@ class ContentCreateMapper implements FormDataMapperInterface
      *
      * @return \Ibexa\ContentForms\Data\Content\ContentCreateData
      */
-    public function mapToFormData(ValueObject $contentType, array $params = [])
+    public function mapToFormData(ValueObject $contentType, array $params = []): ContentCreateData
     {
         $resolver = new OptionsResolver();
         $this->configureOptions($resolver);
@@ -49,7 +49,7 @@ class ContentCreateMapper implements FormDataMapperInterface
         return $data;
     }
 
-    private function configureOptions(OptionsResolver $optionsResolver)
+    private function configureOptions(OptionsResolver $optionsResolver): void
     {
         $optionsResolver
             ->setRequired(['mainLanguageCode', 'parentLocation'])

--- a/src/lib/Data/Mapper/ContentUpdateMapper.php
+++ b/src/lib/Data/Mapper/ContentUpdateMapper.php
@@ -24,7 +24,7 @@ class ContentUpdateMapper implements FormDataMapperInterface
      *
      * @return \Ibexa\ContentForms\Data\Content\ContentUpdateData
      */
-    public function mapToFormData(ValueObject $contentDraft, array $params = [])
+    public function mapToFormData(ValueObject $contentDraft, array $params = []): ContentUpdateData
     {
         $optionsResolver = new OptionsResolver();
         $this->configureOptions($optionsResolver);
@@ -58,7 +58,7 @@ class ContentUpdateMapper implements FormDataMapperInterface
         return $data;
     }
 
-    private function configureOptions(OptionsResolver $optionsResolver)
+    private function configureOptions(OptionsResolver $optionsResolver): void
     {
         $optionsResolver
             ->setRequired(['languageCode', 'contentType', 'currentFields'])

--- a/src/lib/Data/Mapper/UserUpdateMapper.php
+++ b/src/lib/Data/Mapper/UserUpdateMapper.php
@@ -67,7 +67,7 @@ class UserUpdateMapper
         return $data;
     }
 
-    private function configureOptions(OptionsResolver $optionsResolver)
+    private function configureOptions(OptionsResolver $optionsResolver): void
     {
         $optionsResolver->define('filter')->allowedTypes('callable', 'null')->default(null);
         $optionsResolver->setRequired(['languageCode']);

--- a/src/lib/Data/NewnessChecker.php
+++ b/src/lib/Data/NewnessChecker.php
@@ -19,7 +19,7 @@ trait NewnessChecker
      *
      * @return bool
      */
-    public function isNew()
+    public function isNew(): bool
     {
         return strpos($this->getIdentifierValue(), '__new__') === 0;
     }

--- a/src/lib/Data/User/UserCreateData.php
+++ b/src/lib/Data/User/UserCreateData.php
@@ -25,13 +25,13 @@ class UserCreateData extends UserCreateStruct implements NewnessCheckable
     /**
      * @var \Ibexa\Contracts\Core\Repository\Values\User\UserGroup[]
      */
-    private $parentGroups;
+    private ?array $parentGroups = null;
 
     private ?Role $role = null;
 
     private ?RoleLimitation $roleLimitation = null;
 
-    public function isNew()
+    public function isNew(): bool
     {
         return true;
     }
@@ -49,7 +49,7 @@ class UserCreateData extends UserCreateStruct implements NewnessCheckable
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserGroup $parentGroup
      */
-    public function addParentGroup(UserGroup $parentGroup)
+    public function addParentGroup(UserGroup $parentGroup): void
     {
         $this->parentGroups[] = $parentGroup;
     }
@@ -57,7 +57,7 @@ class UserCreateData extends UserCreateStruct implements NewnessCheckable
     /**
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserGroup[] $parentGroups
      */
-    public function setParentGroups(array $parentGroups)
+    public function setParentGroups(array $parentGroups): void
     {
         $this->parentGroups = $parentGroups;
     }

--- a/src/lib/Data/User/UserUpdateData.php
+++ b/src/lib/Data/User/UserUpdateData.php
@@ -30,7 +30,7 @@ class UserUpdateData extends UserUpdateStruct implements NewnessCheckable
      */
     public $contentType;
 
-    public function isNew()
+    public function isNew(): bool
     {
         return false;
     }

--- a/src/lib/Event/ContentCreateFieldOptionsEvent.php
+++ b/src/lib/Event/ContentCreateFieldOptionsEvent.php
@@ -14,8 +14,7 @@ use Symfony\Component\Form\FormInterface;
 
 final class ContentCreateFieldOptionsEvent extends StructFieldOptionsEvent
 {
-    /** @var \Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct */
-    private $contentCreateStruct;
+    private ContentCreateStruct $contentCreateStruct;
 
     public function __construct(
         ContentCreateStruct $contentCreateStruct,

--- a/src/lib/Event/ContentUpdateFieldOptionsEvent.php
+++ b/src/lib/Event/ContentUpdateFieldOptionsEvent.php
@@ -15,11 +15,9 @@ use Symfony\Component\Form\FormInterface;
 
 final class ContentUpdateFieldOptionsEvent extends StructFieldOptionsEvent
 {
-    /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Content */
-    private $content;
+    private Content $content;
 
-    /** @var \Ibexa\Contracts\Core\Repository\Values\Content\ContentUpdateStruct */
-    private $contentUpdateStruct;
+    private ContentUpdateStruct $contentUpdateStruct;
 
     public function __construct(
         Content $content,

--- a/src/lib/Event/FormActionEvent.php
+++ b/src/lib/Event/FormActionEvent.php
@@ -23,24 +23,18 @@ class FormActionEvent extends FormEvent
 
     /**
      * Hash of options.
-     *
-     * @var array
      */
-    private $options;
+    private array $options;
 
     /**
      * Response to return after form post-processing. Typically a RedirectResponse.
-     *
-     * @var \Symfony\Component\HttpFoundation\Response
      */
-    private $response;
+    private ?Response $response = null;
 
     /**
      * Additional payload populated for event listeners next in priority.
-     *
-     * @var array
      */
-    private $payloads;
+    private array $payloads;
 
     /**
      * @param \Symfony\Component\Form\FormInterface $form
@@ -49,7 +43,7 @@ class FormActionEvent extends FormEvent
      * @param array $options
      * @param array $payloads
      */
-    public function __construct(FormInterface $form, $data, $clickedButton, array $options = [], array $payloads = [])
+    public function __construct(FormInterface $form, mixed $data, $clickedButton, array $options = [], array $payloads = [])
     {
         parent::__construct($form, $data);
         $this->clickedButton = $clickedButton;
@@ -93,7 +87,7 @@ class FormActionEvent extends FormEvent
      *
      * @return bool
      */
-    public function hasOption($optionName)
+    public function hasOption($optionName): bool
     {
         return isset($this->options[$optionName]);
     }
@@ -109,12 +103,12 @@ class FormActionEvent extends FormEvent
     /**
      * @param \Symfony\Component\HttpFoundation\Response $response
      */
-    public function setResponse(Response $response)
+    public function setResponse(Response $response): void
     {
         $this->response = $response;
     }
 
-    public function hasResponse()
+    public function hasResponse(): bool
     {
         return $this->response !== null;
     }

--- a/src/lib/EventListener/ViewTemplatesListener.php
+++ b/src/lib/EventListener/ViewTemplatesListener.php
@@ -22,8 +22,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class ViewTemplatesListener implements EventSubscriberInterface
 {
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
     public function __construct(ConfigResolverInterface $configResolver)
     {

--- a/src/lib/FieldType/DataTransformer/AbstractBinaryBaseTransformer.php
+++ b/src/lib/FieldType/DataTransformer/AbstractBinaryBaseTransformer.php
@@ -19,11 +19,9 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  */
 abstract class AbstractBinaryBaseTransformer
 {
-    /** @var \Ibexa\Contracts\Core\Repository\FieldType */
-    protected $fieldType;
+    protected FieldType $fieldType;
 
-    /** @var \Ibexa\Core\FieldType\Value */
-    protected $initialValue;
+    protected Value $initialValue;
 
     /** @var string */
     protected $valueClass;

--- a/src/lib/FieldType/DataTransformer/FieldValueTransformer.php
+++ b/src/lib/FieldType/DataTransformer/FieldValueTransformer.php
@@ -18,10 +18,7 @@ use Symfony\Component\Form\DataTransformerInterface;
  */
 class FieldValueTransformer implements DataTransformerInterface
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\FieldType
-     */
-    private $fieldType;
+    private FieldType $fieldType;
 
     public function __construct(FieldType $fieldType)
     {

--- a/src/lib/FieldType/DataTransformer/MultipleCountryValueTransformer.php
+++ b/src/lib/FieldType/DataTransformer/MultipleCountryValueTransformer.php
@@ -20,7 +20,7 @@ class MultipleCountryValueTransformer implements DataTransformerInterface
     /**
      * @var array Array of countries from "ibexa.field_type.country.data"
      */
-    protected $countriesInfo;
+    protected array $countriesInfo;
 
     /**
      * @param array $countriesInfo

--- a/src/lib/FieldType/DataTransformer/SingleCountryValueTransformer.php
+++ b/src/lib/FieldType/DataTransformer/SingleCountryValueTransformer.php
@@ -21,7 +21,7 @@ class SingleCountryValueTransformer implements DataTransformerInterface
     /**
      * @var array Array of countries from "ibexa.field_type.country.data"
      */
-    protected $countriesInfo;
+    protected array $countriesInfo;
 
     /**
      * @param array $countriesInfo

--- a/src/lib/FieldType/FieldTypeFormMapperDispatcher.php
+++ b/src/lib/FieldType/FieldTypeFormMapperDispatcher.php
@@ -24,7 +24,7 @@ class FieldTypeFormMapperDispatcher implements FieldTypeFormMapperDispatcherInte
      *
      * @var \Ibexa\Contracts\ContentForms\FieldType\FieldValueFormMapperInterface[]
      */
-    private $mappers;
+    private array $mappers;
 
     /**
      * FieldTypeFormMapperDispatcher constructor.

--- a/src/lib/FieldType/Mapper/AbstractRelationFormMapper.php
+++ b/src/lib/FieldType/Mapper/AbstractRelationFormMapper.php
@@ -22,12 +22,12 @@ abstract class AbstractRelationFormMapper implements FieldValueFormMapperInterfa
     /**
      * @var \Ibexa\Contracts\Core\Repository\ContentTypeService Used to fetch list of available content types
      */
-    protected $contentTypeService;
+    protected ContentTypeService $contentTypeService;
 
     /**
      * @var \Ibexa\Contracts\Core\Repository\LocationService Used to fetch selection root
      */
-    protected $locationService;
+    protected LocationService $locationService;
 
     /**
      * @param \Ibexa\Contracts\Core\Repository\ContentTypeService $contentTypeService

--- a/src/lib/FieldType/Mapper/AuthorFormMapper.php
+++ b/src/lib/FieldType/Mapper/AuthorFormMapper.php
@@ -22,7 +22,7 @@ class AuthorFormMapper implements FieldValueFormMapperInterface
      * @param \Symfony\Component\Form\FormInterface $fieldForm
      * @param \Ibexa\Contracts\ContentForms\Data\Content\FieldData $data
      */
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $fieldSettings = $fieldDefinition->getFieldSettings();

--- a/src/lib/FieldType/Mapper/BinaryFileFormMapper.php
+++ b/src/lib/FieldType/Mapper/BinaryFileFormMapper.php
@@ -18,15 +18,14 @@ use Symfony\Component\Form\FormInterface;
 
 class BinaryFileFormMapper implements FieldValueFormMapperInterface
 {
-    /** @var \Ibexa\Contracts\Core\Repository\FieldTypeService */
-    private $fieldTypeService;
+    private FieldTypeService $fieldTypeService;
 
     public function __construct(FieldTypeService $fieldTypeService)
     {
         $this->fieldTypeService = $fieldTypeService;
     }
 
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();

--- a/src/lib/FieldType/Mapper/CheckboxFormMapper.php
+++ b/src/lib/FieldType/Mapper/CheckboxFormMapper.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormInterface;
  */
 class CheckboxFormMapper implements FieldValueFormMapperInterface
 {
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();

--- a/src/lib/FieldType/Mapper/CountryFormMapper.php
+++ b/src/lib/FieldType/Mapper/CountryFormMapper.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\FormInterface;
 
 class CountryFormMapper implements FieldValueFormMapperInterface
 {
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $fieldSettings = $fieldDefinition->getFieldSettings();

--- a/src/lib/FieldType/Mapper/DateFormMapper.php
+++ b/src/lib/FieldType/Mapper/DateFormMapper.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormInterface;
  */
 class DateFormMapper implements FieldValueFormMapperInterface
 {
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();

--- a/src/lib/FieldType/Mapper/DateTimeFormMapper.php
+++ b/src/lib/FieldType/Mapper/DateTimeFormMapper.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormInterface;
  */
 class DateTimeFormMapper implements FieldValueFormMapperInterface
 {
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $fieldSettings = $fieldDefinition->getFieldSettings();

--- a/src/lib/FieldType/Mapper/FloatFormMapper.php
+++ b/src/lib/FieldType/Mapper/FloatFormMapper.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormInterface;
  */
 class FloatFormMapper implements FieldValueFormMapperInterface
 {
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();

--- a/src/lib/FieldType/Mapper/FormTypeBasedFieldValueFormMapper.php
+++ b/src/lib/FieldType/Mapper/FormTypeBasedFieldValueFormMapper.php
@@ -39,17 +39,14 @@ final class FormTypeBasedFieldValueFormMapper implements FieldValueFormMapperInt
      */
     private $formType;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\FieldTypeService
-     */
-    private $fieldTypeService;
+    private FieldTypeService $fieldTypeService;
 
     public function __construct(FieldTypeService $fieldTypeService)
     {
         $this->fieldTypeService = $fieldTypeService;
     }
 
-    public function setFormType($formType)
+    public function setFormType($formType): void
     {
         $this->formType = $formType;
     }
@@ -60,7 +57,7 @@ final class FormTypeBasedFieldValueFormMapper implements FieldValueFormMapperInt
      * @param \Symfony\Component\Form\FormInterface $fieldForm form for the current Field
      * @param \Ibexa\Contracts\ContentForms\Data\Content\FieldData $data underlying data for current Field form
      */
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();

--- a/src/lib/FieldType/Mapper/ISBNFormMapper.php
+++ b/src/lib/FieldType/Mapper/ISBNFormMapper.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\FormInterface;
 
 class ISBNFormMapper implements FieldValueFormMapperInterface
 {
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();

--- a/src/lib/FieldType/Mapper/ImageAssetFormMapper.php
+++ b/src/lib/FieldType/Mapper/ImageAssetFormMapper.php
@@ -18,8 +18,7 @@ use Symfony\Component\Form\FormInterface;
 
 class ImageAssetFormMapper implements FieldValueFormMapperInterface
 {
-    /** @var \Ibexa\Contracts\Core\Repository\FieldTypeService */
-    private $fieldTypeService;
+    private FieldTypeService $fieldTypeService;
 
     /**
      * @param \Ibexa\Contracts\Core\Repository\FieldTypeService $fieldTypeService

--- a/src/lib/FieldType/Mapper/ImageFormMapper.php
+++ b/src/lib/FieldType/Mapper/ImageFormMapper.php
@@ -18,15 +18,14 @@ use Symfony\Component\Form\FormInterface;
 
 class ImageFormMapper implements FieldValueFormMapperInterface
 {
-    /** @var \Ibexa\Contracts\Core\Repository\FieldTypeService */
-    private $fieldTypeService;
+    private FieldTypeService $fieldTypeService;
 
     public function __construct(FieldTypeService $fieldTypeService)
     {
         $this->fieldTypeService = $fieldTypeService;
     }
 
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();

--- a/src/lib/FieldType/Mapper/IntegerFormMapper.php
+++ b/src/lib/FieldType/Mapper/IntegerFormMapper.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormInterface;
  */
 class IntegerFormMapper implements FieldValueFormMapperInterface
 {
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();

--- a/src/lib/FieldType/Mapper/KeywordFormMapper.php
+++ b/src/lib/FieldType/Mapper/KeywordFormMapper.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormInterface;
  */
 class KeywordFormMapper implements FieldValueFormMapperInterface
 {
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();

--- a/src/lib/FieldType/Mapper/MapLocationFormMapper.php
+++ b/src/lib/FieldType/Mapper/MapLocationFormMapper.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormInterface;
  */
 class MapLocationFormMapper implements FieldValueFormMapperInterface
 {
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();

--- a/src/lib/FieldType/Mapper/MediaFormMapper.php
+++ b/src/lib/FieldType/Mapper/MediaFormMapper.php
@@ -19,8 +19,7 @@ use Symfony\Component\Form\FormInterface;
 
 class MediaFormMapper implements FieldValueFormMapperInterface
 {
-    /** @var \Ibexa\Contracts\Core\Repository\FieldTypeService */
-    private $fieldTypeService;
+    private FieldTypeService $fieldTypeService;
 
     protected const ACCEPT_VIDEO = 'video/*';
     protected const ACCEPT_AUDIO = 'audio/*';
@@ -30,7 +29,7 @@ class MediaFormMapper implements FieldValueFormMapperInterface
         $this->fieldTypeService = $fieldTypeService;
     }
 
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();

--- a/src/lib/FieldType/Mapper/RelationFormMapper.php
+++ b/src/lib/FieldType/Mapper/RelationFormMapper.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\FormInterface;
 
 class RelationFormMapper extends AbstractRelationFormMapper
 {
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();

--- a/src/lib/FieldType/Mapper/RelationListFormMapper.php
+++ b/src/lib/FieldType/Mapper/RelationListFormMapper.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\FormInterface;
 
 class RelationListFormMapper extends AbstractRelationFormMapper
 {
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();

--- a/src/lib/FieldType/Mapper/SelectionFormMapper.php
+++ b/src/lib/FieldType/Mapper/SelectionFormMapper.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\FormInterface;
 
 class SelectionFormMapper implements FieldValueFormMapperInterface
 {
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();

--- a/src/lib/FieldType/Mapper/TextBlockFormMapper.php
+++ b/src/lib/FieldType/Mapper/TextBlockFormMapper.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormInterface;
  */
 class TextBlockFormMapper implements FieldValueFormMapperInterface
 {
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();

--- a/src/lib/FieldType/Mapper/TextLineFormMapper.php
+++ b/src/lib/FieldType/Mapper/TextLineFormMapper.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormInterface;
  */
 class TextLineFormMapper implements FieldValueFormMapperInterface
 {
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();

--- a/src/lib/FieldType/Mapper/TimeFormMapper.php
+++ b/src/lib/FieldType/Mapper/TimeFormMapper.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormInterface;
  */
 class TimeFormMapper implements FieldValueFormMapperInterface
 {
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $fieldSettings = $fieldDefinition->getFieldSettings();

--- a/src/lib/FieldType/Mapper/UrlFormMapper.php
+++ b/src/lib/FieldType/Mapper/UrlFormMapper.php
@@ -22,7 +22,7 @@ class UrlFormMapper implements FieldValueFormMapperInterface
      * @param \Symfony\Component\Form\FormInterface $fieldForm
      * @param \Ibexa\Contracts\ContentForms\Data\Content\FieldData $data
      */
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();

--- a/src/lib/FieldType/Mapper/UserAccountFieldValueFormMapper.php
+++ b/src/lib/FieldType/Mapper/UserAccountFieldValueFormMapper.php
@@ -35,7 +35,7 @@ final class UserAccountFieldValueFormMapper implements FieldValueFormMapperInter
      * @throws \Symfony\Component\Form\Exception\UnexpectedTypeException
      * @throws \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();
@@ -67,7 +67,7 @@ final class UserAccountFieldValueFormMapper implements FieldValueFormMapperInter
      *
      * @throws \Symfony\Component\OptionsResolver\Exception\AccessException
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([
@@ -83,7 +83,7 @@ final class UserAccountFieldValueFormMapper implements FieldValueFormMapperInter
     public function getModelTransformerForTranslation(FieldDefinition $fieldDefinition): CallbackTransformer
     {
         return new CallbackTransformer(
-            static function (ApiUserValue $data) {
+            static function (ApiUserValue $data): UserAccountFieldData {
                 return new UserAccountFieldData($data->login, null, $data->email, $data->enabled);
             },
             static function (UserAccountFieldData $submittedData) use ($fieldDefinition) {
@@ -103,10 +103,10 @@ final class UserAccountFieldValueFormMapper implements FieldValueFormMapperInter
     public function getModelTransformer(): CallbackTransformer
     {
         return new CallbackTransformer(
-            static function (ApiUserValue $data) {
+            static function (ApiUserValue $data): UserAccountFieldData {
                 return new UserAccountFieldData($data->login, null, $data->email, $data->enabled);
             },
-            static function (UserAccountFieldData $submittedData) {
+            static function (UserAccountFieldData $submittedData): UserAccountFieldData {
                 return $submittedData;
             }
         );

--- a/src/lib/Form/ActionDispatcher/AbstractActionDispatcher.php
+++ b/src/lib/Form/ActionDispatcher/AbstractActionDispatcher.php
@@ -19,22 +19,19 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 abstract class AbstractActionDispatcher implements ActionDispatcherInterface
 {
-    /**
-     * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
-     */
-    private $eventDispatcher;
+    private ?EventDispatcherInterface $eventDispatcher = null;
 
     /**
      * @var \Symfony\Component\HttpFoundation\Response
      */
     protected $response;
 
-    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher)
+    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher): void
     {
         $this->eventDispatcher = $eventDispatcher;
     }
 
-    public function dispatchFormAction(FormInterface $form, ValueObject $data, $actionName = null, array $options = [])
+    public function dispatchFormAction(FormInterface $form, ValueObject $data, $actionName = null, array $options = []): void
     {
         $resolver = new OptionsResolver();
         $this->configureOptions($resolver);
@@ -74,7 +71,7 @@ abstract class AbstractActionDispatcher implements ActionDispatcherInterface
      * @param $defaultActionEventName
      * @param $event
      */
-    protected function dispatchDefaultAction($defaultActionEventName, FormActionEvent $event)
+    protected function dispatchDefaultAction(?string $defaultActionEventName, FormActionEvent $event)
     {
         $this->eventDispatcher->dispatch($event, $defaultActionEventName);
     }
@@ -83,7 +80,7 @@ abstract class AbstractActionDispatcher implements ActionDispatcherInterface
      * @param $actionEventName
      * @param $event
      */
-    protected function dispatchAction($actionEventName, FormActionEvent $event)
+    protected function dispatchAction(?string $actionEventName, FormActionEvent $event)
     {
         $this->eventDispatcher->dispatch($event, $actionEventName);
     }

--- a/src/lib/Form/ActionDispatcher/ContentDispatcher.php
+++ b/src/lib/Form/ActionDispatcher/ContentDispatcher.php
@@ -21,7 +21,7 @@ class ContentDispatcher extends AbstractActionDispatcher
         $resolver->setAllowedTypes('referrerLocation', [Location::class, 'null']);
     }
 
-    protected function getActionEventBaseName()
+    protected function getActionEventBaseName(): string
     {
         return ContentFormEvents::CONTENT_EDIT;
     }

--- a/src/lib/Form/ActionDispatcher/UserDispatcher.php
+++ b/src/lib/Form/ActionDispatcher/UserDispatcher.php
@@ -12,7 +12,7 @@ use Ibexa\ContentForms\Event\ContentFormEvents;
 
 class UserDispatcher extends AbstractActionDispatcher
 {
-    protected function getActionEventBaseName()
+    protected function getActionEventBaseName(): string
     {
         return ContentFormEvents::USER_EDIT;
     }

--- a/src/lib/Form/EventSubscriber/SuppressValidationSubscriber.php
+++ b/src/lib/Form/EventSubscriber/SuppressValidationSubscriber.php
@@ -29,7 +29,7 @@ class SuppressValidationSubscriber implements EventSubscriberInterface
         ];
     }
 
-    public function suppressValidationOnCancel(FormEvent $event)
+    public function suppressValidationOnCancel(FormEvent $event): void
     {
         $form = $event->getForm();
 
@@ -38,7 +38,7 @@ class SuppressValidationSubscriber implements EventSubscriberInterface
         }
     }
 
-    public function suppressValidationOnSaveDraft(PostSubmitEvent $event)
+    public function suppressValidationOnSaveDraft(PostSubmitEvent $event): void
     {
         $form = $event->getForm();
 
@@ -50,7 +50,7 @@ class SuppressValidationSubscriber implements EventSubscriberInterface
         }
     }
 
-    public function suppressValidationOnAutosaveDraft(PostSubmitEvent $event)
+    public function suppressValidationOnAutosaveDraft(PostSubmitEvent $event): void
     {
         $form = $event->getForm();
 

--- a/src/lib/Form/EventSubscriber/UserFieldsSubscriber.php
+++ b/src/lib/Form/EventSubscriber/UserFieldsSubscriber.php
@@ -35,7 +35,7 @@ class UserFieldsSubscriber implements EventSubscriberInterface
      *
      * @param \Symfony\Component\Form\FormEvent $event
      */
-    public function handleUserAccountField(FormEvent $event)
+    public function handleUserAccountField(FormEvent $event): void
     {
         /** @var \Ibexa\ContentForms\Data\User\UserCreateData|\Ibexa\ContentForms\Data\User\UserUpdateData $data */
         $data = $event->getData();
@@ -52,7 +52,7 @@ class UserFieldsSubscriber implements EventSubscriberInterface
     /**
      * @param \Ibexa\ContentForms\Data\User\UserCreateData $data
      */
-    private function handleUserCreateData(UserCreateData $data)
+    private function handleUserCreateData(UserCreateData $data): void
     {
         foreach ($data->fieldsData as $fieldData) {
             if ('ezuser' !== $fieldData->getFieldTypeIdentifier()) {
@@ -84,7 +84,7 @@ class UserFieldsSubscriber implements EventSubscriberInterface
      * @param \Ibexa\ContentForms\Data\User\UserUpdateData $data
      * @param $languageCode
      */
-    private function handleUserUpdateData(UserUpdateData $data, $languageCode)
+    private function handleUserUpdateData(UserUpdateData $data, ?string $languageCode): void
     {
         foreach ($data->fieldsData as $fieldData) {
             if ('ezuser' !== $fieldData->getFieldTypeIdentifier()) {

--- a/src/lib/Form/Processor/ContentFormProcessor.php
+++ b/src/lib/Form/Processor/ContentFormProcessor.php
@@ -30,14 +30,11 @@ use Symfony\Component\Routing\RouterInterface;
  */
 class ContentFormProcessor implements EventSubscriberInterface
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ContentService */
-    private $contentService;
+    private ContentService $contentService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\LocationService */
-    private $locationService;
+    private LocationService $locationService;
 
-    /** @var \Symfony\Component\Routing\RouterInterface */
-    private $router;
+    private RouterInterface $router;
 
     /**
      * @param \Ibexa\Contracts\Core\Repository\ContentService $contentService
@@ -81,7 +78,7 @@ class ContentFormProcessor implements EventSubscriberInterface
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentException
      */
-    public function processSaveDraft(FormActionEvent $event)
+    public function processSaveDraft(FormActionEvent $event): void
     {
         /** @var \Ibexa\ContentForms\Data\Content\ContentCreateData|\Ibexa\ContentForms\Data\Content\ContentUpdateData $data */
         $data = $event->getData();
@@ -169,7 +166,7 @@ class ContentFormProcessor implements EventSubscriberInterface
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentException
      */
-    public function processPublish(FormActionEvent $event)
+    public function processPublish(FormActionEvent $event): void
     {
         /** @var \Ibexa\ContentForms\Data\Content\ContentCreateData|\Ibexa\ContentForms\Data\Content\ContentUpdateData $data */
         $data = $event->getData();
@@ -208,7 +205,7 @@ class ContentFormProcessor implements EventSubscriberInterface
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentException
      */
-    public function processPublishAndEdit(FormActionEvent $event)
+    public function processPublishAndEdit(FormActionEvent $event): void
     {
         /** @var \Ibexa\ContentForms\Data\Content\ContentCreateData|\Ibexa\ContentForms\Data\Content\ContentUpdateData $data */
         $data = $event->getData();
@@ -244,7 +241,7 @@ class ContentFormProcessor implements EventSubscriberInterface
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
      */
-    public function processCancel(FormActionEvent $event)
+    public function processCancel(FormActionEvent $event): void
     {
         /** @var \Ibexa\ContentForms\Data\Content\ContentCreateData|\Ibexa\ContentForms\Data\Content\ContentUpdateData $data */
         $data = $event->getData();
@@ -299,7 +296,7 @@ class ContentFormProcessor implements EventSubscriberInterface
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
      */
-    public function processCreateDraft(FormActionEvent $event)
+    public function processCreateDraft(FormActionEvent $event): void
     {
         /** @var $createContentDraft \Ibexa\ContentForms\Data\Content\CreateContentDraftData */
         $createContentDraft = $event->getData();
@@ -364,7 +361,7 @@ class ContentFormProcessor implements EventSubscriberInterface
      *
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentException
      */
-    private function resolveMainLanguageCode($data): string
+    private function resolveMainLanguageCode(ContentStruct $data): string
     {
         if (!$data instanceof ContentUpdateData && !$data instanceof ContentCreateData) {
             throw new InvalidArgumentException(

--- a/src/lib/Form/Processor/SystemUrlRedirectProcessor.php
+++ b/src/lib/Form/Processor/SystemUrlRedirectProcessor.php
@@ -18,14 +18,11 @@ use Symfony\Component\Routing\RouterInterface;
 
 class SystemUrlRedirectProcessor implements EventSubscriberInterface
 {
-    /** @var \Symfony\Component\Routing\RouterInterface */
-    private $router;
+    private RouterInterface $router;
 
-    /** @var \Ibexa\Contracts\Core\Repository\URLAliasService */
-    private $urlAliasService;
+    private URLAliasService $urlAliasService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\LocationService */
-    private $locationService;
+    private LocationService $locationService;
 
     /**
      * @param \Symfony\Component\Routing\RouterInterface $router

--- a/src/lib/Form/Processor/User/UserCancelFormProcessor.php
+++ b/src/lib/Form/Processor/User/UserCancelFormProcessor.php
@@ -19,8 +19,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  */
 class UserCancelFormProcessor implements EventSubscriberInterface
 {
-    /** @var \Symfony\Component\Routing\Generator\UrlGeneratorInterface */
-    private $urlGenerator;
+    private UrlGeneratorInterface $urlGenerator;
 
     /**
      * @param \Symfony\Component\Routing\Generator\UrlGeneratorInterface $urlGenerator
@@ -38,7 +37,7 @@ class UserCancelFormProcessor implements EventSubscriberInterface
         ];
     }
 
-    public function processCancel(FormActionEvent $event)
+    public function processCancel(FormActionEvent $event): void
     {
         /** @var \Ibexa\ContentForms\Data\User\UserUpdateData|\Ibexa\ContentForms\Data\User\UserCreateData $data */
         $data = $event->getData();

--- a/src/lib/Form/Processor/User/UserCreateFormProcessor.php
+++ b/src/lib/Form/Processor/User/UserCreateFormProcessor.php
@@ -21,11 +21,9 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  */
 class UserCreateFormProcessor implements EventSubscriberInterface
 {
-    /** @var \Ibexa\Contracts\Core\Repository\UserService */
-    private $userService;
+    private UserService $userService;
 
-    /** @var \Symfony\Component\Routing\Generator\UrlGeneratorInterface */
-    private $urlGenerator;
+    private UrlGeneratorInterface $urlGenerator;
 
     /**
      * @param \Ibexa\Contracts\Core\Repository\UserService $userService
@@ -46,7 +44,7 @@ class UserCreateFormProcessor implements EventSubscriberInterface
         ];
     }
 
-    public function processCreate(FormActionEvent $event)
+    public function processCreate(FormActionEvent $event): void
     {
         $data = $data = $event->getData();
 

--- a/src/lib/Form/Processor/User/UserUpdateFormProcessor.php
+++ b/src/lib/Form/Processor/User/UserUpdateFormProcessor.php
@@ -22,14 +22,11 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  */
 class UserUpdateFormProcessor implements EventSubscriberInterface
 {
-    /** @var \Ibexa\Contracts\Core\Repository\UserService */
-    private $userService;
+    private UserService $userService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\ContentService */
-    private $contentService;
+    private ContentService $contentService;
 
-    /** @var \Symfony\Component\Routing\Generator\UrlGeneratorInterface */
-    private $urlGenerator;
+    private UrlGeneratorInterface $urlGenerator;
 
     public function __construct(
         UserService $userService,
@@ -48,7 +45,7 @@ class UserUpdateFormProcessor implements EventSubscriberInterface
         ];
     }
 
-    public function processUpdate(FormActionEvent $event)
+    public function processUpdate(FormActionEvent $event): void
     {
         $data = $event->getData();
 

--- a/src/lib/Form/Type/Content/BaseContentType.php
+++ b/src/lib/Form/Type/Content/BaseContentType.php
@@ -25,7 +25,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class BaseContentType extends AbstractType
 {
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }
@@ -58,7 +58,7 @@ class BaseContentType extends AbstractType
             ]);
     }
 
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['languageCode'] = $options['languageCode'];
         $view->vars['mainLanguageCode'] = $options['mainLanguageCode'];

--- a/src/lib/Form/Type/Content/ContentDraftCreateType.php
+++ b/src/lib/Form/Type/Content/ContentDraftCreateType.php
@@ -16,7 +16,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ContentDraftCreateType extends AbstractType
 {
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/src/lib/Form/Type/Content/ContentEditType.php
+++ b/src/lib/Form/Type/Content/ContentEditType.php
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ContentEditType extends AbstractType
 {
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/src/lib/Form/Type/Content/ContentFieldType.php
+++ b/src/lib/Form/Type/Content/ContentFieldType.php
@@ -26,17 +26,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ContentFieldType extends AbstractType
 {
-    /**
-     * @var \Ibexa\ContentForms\FieldType\FieldTypeFormMapperDispatcherInterface
-     */
-    private $fieldTypeFormMapper;
+    private FieldTypeFormMapperDispatcherInterface $fieldTypeFormMapper;
 
     public function __construct(FieldTypeFormMapperDispatcherInterface $fieldTypeFormMapper)
     {
         $this->fieldTypeFormMapper = $fieldTypeFormMapper;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }
@@ -99,7 +96,7 @@ class ContentFieldType extends AbstractType
             );
     }
 
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['location'] = $options['location'];
         $view->vars['languageCode'] = $options['languageCode'];
@@ -108,7 +105,7 @@ class ContentFieldType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event): void {
             $this->fieldTypeFormMapper->map($event->getForm(), $event->getData());
         });
     }

--- a/src/lib/Form/Type/Content/FieldCollectionType.php
+++ b/src/lib/Form/Type/Content/FieldCollectionType.php
@@ -28,8 +28,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class FieldCollectionType extends CollectionType
 {
-    /** @var \Symfony\Contracts\EventDispatcher\EventDispatcherInterface */
-    private $eventDispatcher;
+    private EventDispatcherInterface $eventDispatcher;
 
     public function __construct(
         EventDispatcherInterface $eventDispatcher
@@ -43,7 +42,7 @@ class FieldCollectionType extends CollectionType
     ): void {
         parent::buildForm($builder, $options);
 
-        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($options) {
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($options): void {
             $form = $event->getForm();
             $data = $event->getData();
 

--- a/src/lib/Form/Type/FieldType/Author/AuthorCollectionType.php
+++ b/src/lib/Form/Type/FieldType/Author/AuthorCollectionType.php
@@ -17,7 +17,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class AuthorCollectionType extends AbstractType
 {
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/src/lib/Form/Type/FieldType/Author/AuthorEntryType.php
+++ b/src/lib/Form/Type/FieldType/Author/AuthorEntryType.php
@@ -25,7 +25,7 @@ class AuthorEntryType extends AbstractType
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/src/lib/Form/Type/FieldType/AuthorFieldType.php
+++ b/src/lib/Form/Type/FieldType/AuthorFieldType.php
@@ -29,8 +29,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class AuthorFieldType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\Repository\Repository */
-    private $repository;
+    private Repository $repository;
 
     /** @var int */
     private $defaultAuthor;
@@ -46,7 +45,7 @@ class AuthorFieldType extends AbstractType
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }
@@ -78,7 +77,7 @@ class AuthorFieldType extends AbstractType
      * @param \Symfony\Component\Form\FormInterface $form
      * @param array $options
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['attr']['default-author'] = $options['default_author'];
     }
@@ -101,7 +100,7 @@ class AuthorFieldType extends AbstractType
      */
     public function getViewTransformer(): DataTransformerInterface
     {
-        return new CallbackTransformer(function (Value $value) {
+        return new CallbackTransformer(function (Value $value): Value {
             if (0 === $value->authors->count()) {
                 if ($this->defaultAuthor === AuthorType::DEFAULT_CURRENT_USER) {
                     $value->authors->append($this->fetchLoggedAuthor());
@@ -111,7 +110,7 @@ class AuthorFieldType extends AbstractType
             }
 
             return $value;
-        }, static function (Value $value) {
+        }, static function (Value $value): Value {
             return $value;
         });
     }
@@ -119,14 +118,14 @@ class AuthorFieldType extends AbstractType
     /**
      * @param \Symfony\Component\Form\FormEvent $event
      */
-    public function filterOutEmptyAuthors(FormEvent $event)
+    public function filterOutEmptyAuthors(FormEvent $event): void
     {
         $value = $event->getData();
 
         $value->authors->exchangeArray(
             array_filter(
                 $value->authors->getArrayCopy(),
-                static function (Author $author) {
+                static function (Author $author): bool {
                     return !empty($author->email) || !empty($author->name);
                 }
             )

--- a/src/lib/Form/Type/FieldType/BinaryBaseFieldType.php
+++ b/src/lib/Form/Type/FieldType/BinaryBaseFieldType.php
@@ -24,8 +24,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 class BinaryBaseFieldType extends AbstractType
 {
-    /** @var \Ibexa\ContentForms\ConfigResolver\MaxUploadSize */
-    private $maxUploadSize;
+    private MaxUploadSize $maxUploadSize;
 
     public function __construct(MaxUploadSize $maxUploadSize)
     {
@@ -57,7 +56,7 @@ class BinaryBaseFieldType extends AbstractType
             );
     }
 
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['max_upload_size'] = $this->maxUploadSize->get();
     }

--- a/src/lib/Form/Type/FieldType/BinaryFileFieldType.php
+++ b/src/lib/Form/Type/FieldType/BinaryFileFieldType.php
@@ -16,7 +16,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class BinaryFileFieldType extends AbstractType
 {
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/src/lib/Form/Type/FieldType/CheckboxFieldType.php
+++ b/src/lib/Form/Type/FieldType/CheckboxFieldType.php
@@ -19,15 +19,14 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class CheckboxFieldType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\Repository\FieldTypeService */
-    protected $fieldTypeService;
+    protected FieldTypeService $fieldTypeService;
 
     public function __construct(FieldTypeService $fieldTypeService)
     {
         $this->fieldTypeService = $fieldTypeService;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/src/lib/Form/Type/FieldType/CountryFieldType.php
+++ b/src/lib/Form/Type/FieldType/CountryFieldType.php
@@ -20,8 +20,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class CountryFieldType extends AbstractType
 {
-    /** @var array */
-    protected $countriesInfo;
+    protected array $countriesInfo;
 
     /**
      * @param array $countriesInfo
@@ -31,7 +30,7 @@ class CountryFieldType extends AbstractType
         $this->countriesInfo = $countriesInfo;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }
@@ -63,7 +62,10 @@ class CountryFieldType extends AbstractType
         ]);
     }
 
-    private function getCountryChoices(array $countriesInfo)
+    /**
+     * @return mixed[]
+     */
+    private function getCountryChoices(array $countriesInfo): array
     {
         $choices = [];
         foreach ($countriesInfo as $country) {

--- a/src/lib/Form/Type/FieldType/DateFieldType.php
+++ b/src/lib/Form/Type/FieldType/DateFieldType.php
@@ -23,15 +23,14 @@ class DateFieldType extends AbstractType
 {
     private const EDIT_VIEWS = ['ibexa.content.draft.edit', 'ibexa.content.translate', 'ibexa.content.translate_with_location', 'ibexa.user.update'];
 
-    /** @var \Symfony\Component\HttpFoundation\RequestStack */
-    private $requestStack;
+    private RequestStack $requestStack;
 
     public function __construct(RequestStack $requestStack)
     {
         $this->requestStack = $requestStack;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }
@@ -52,7 +51,7 @@ class DateFieldType extends AbstractType
             ->addModelTransformer(new DateValueTransformer());
     }
 
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $request = $this->requestStack->getCurrentRequest();
         $view->vars['isEditView'] = \in_array($request->attributes->get('_route'), self::EDIT_VIEWS);

--- a/src/lib/Form/Type/FieldType/DateTimeFieldType.php
+++ b/src/lib/Form/Type/FieldType/DateTimeFieldType.php
@@ -21,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class DateTimeFieldType extends AbstractType
 {
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }
@@ -42,7 +42,7 @@ class DateTimeFieldType extends AbstractType
             ->addModelTransformer(new DateTimeValueTransformer());
     }
 
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['attr']['data-seconds'] = (int) $options['with_seconds'];
     }

--- a/src/lib/Form/Type/FieldType/FloatFieldType.php
+++ b/src/lib/Form/Type/FieldType/FloatFieldType.php
@@ -22,15 +22,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class FloatFieldType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\Repository\FieldTypeService */
-    protected $fieldTypeService;
+    protected FieldTypeService $fieldTypeService;
 
     public function __construct(FieldTypeService $fieldTypeService)
     {
         $this->fieldTypeService = $fieldTypeService;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }
@@ -52,7 +51,7 @@ class FloatFieldType extends AbstractType
         $builder->resetViewTransformers();
     }
 
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $attributes = ['step' => 'any'];
 

--- a/src/lib/Form/Type/FieldType/ISBNFieldType.php
+++ b/src/lib/Form/Type/FieldType/ISBNFieldType.php
@@ -19,15 +19,14 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class ISBNFieldType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\Repository\FieldTypeService */
-    protected $fieldTypeService;
+    protected FieldTypeService $fieldTypeService;
 
     public function __construct(FieldTypeService $fieldTypeService)
     {
         $this->fieldTypeService = $fieldTypeService;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/src/lib/Form/Type/FieldType/ImageAssetFieldType.php
+++ b/src/lib/Form/Type/FieldType/ImageAssetFieldType.php
@@ -27,14 +27,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ImageAssetFieldType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ContentService */
-    private $contentService;
+    private ContentService $contentService;
 
-    /** @var \Ibexa\Core\FieldType\ImageAsset\AssetMapper */
-    private $assetMapper;
+    private AssetMapper $assetMapper;
 
-    /** @var \Ibexa\ContentForms\ConfigResolver\MaxUploadSize */
-    private $maxUploadSize;
+    private MaxUploadSize $maxUploadSize;
 
     private MimeTypesInterface $mimeTypes;
 
@@ -50,7 +47,7 @@ class ImageAssetFieldType extends AbstractType
         $this->mimeTypes = $mimeTypes;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }
@@ -91,7 +88,7 @@ class ImageAssetFieldType extends AbstractType
             );
     }
 
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['destination_content'] = null;
 

--- a/src/lib/Form/Type/FieldType/ImageFieldType.php
+++ b/src/lib/Form/Type/FieldType/ImageFieldType.php
@@ -30,7 +30,7 @@ class ImageFieldType extends AbstractType
         $this->mimeTypes = $mimeTypes;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }
@@ -63,7 +63,7 @@ class ImageFieldType extends AbstractType
             );
     }
 
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars += [
             'is_alternative_text_required' => $options['is_alternative_text_required'],

--- a/src/lib/Form/Type/FieldType/IntegerFieldType.php
+++ b/src/lib/Form/Type/FieldType/IntegerFieldType.php
@@ -22,15 +22,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class IntegerFieldType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\Repository\FieldTypeService */
-    private $fieldTypeService;
+    private FieldTypeService $fieldTypeService;
 
     public function __construct(FieldTypeService $fieldTypeService)
     {
         $this->fieldTypeService = $fieldTypeService;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }
@@ -60,7 +59,7 @@ class IntegerFieldType extends AbstractType
         $builder->addModelTransformer(new FieldValueTransformer($this->fieldTypeService->getFieldType('ezinteger')));
     }
 
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $attributes = ['step' => 1];
 

--- a/src/lib/Form/Type/FieldType/KeywordFieldType.php
+++ b/src/lib/Form/Type/FieldType/KeywordFieldType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class KeywordFieldType extends AbstractType
 {
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/src/lib/Form/Type/FieldType/MapLocationFieldType.php
+++ b/src/lib/Form/Type/FieldType/MapLocationFieldType.php
@@ -24,15 +24,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class MapLocationFieldType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\Repository\FieldTypeService */
-    protected $fieldTypeService;
+    protected FieldTypeService $fieldTypeService;
 
     public function __construct(FieldTypeService $fieldTypeService)
     {
         $this->fieldTypeService = $fieldTypeService;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }
@@ -87,7 +86,7 @@ class MapLocationFieldType extends AbstractType
             );
     }
 
-    public function finishView(FormView $view, FormInterface $form, array $options)
+    public function finishView(FormView $view, FormInterface $form, array $options): void
     {
         $view->children['latitude']->vars['type'] = 'number';
         $view->children['longitude']->vars['type'] = 'number';

--- a/src/lib/Form/Type/FieldType/MediaFieldType.php
+++ b/src/lib/Form/Type/FieldType/MediaFieldType.php
@@ -20,7 +20,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class MediaFieldType extends AbstractType
 {
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/src/lib/Form/Type/FieldType/RelationFieldType.php
+++ b/src/lib/Form/Type/FieldType/RelationFieldType.php
@@ -26,11 +26,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class RelationFieldType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ContentService */
-    private $contentService;
+    private ContentService $contentService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
     /**
      * @param \Ibexa\Contracts\Core\Repository\ContentService $contentService
@@ -42,7 +40,7 @@ class RelationFieldType extends AbstractType
         $this->contentTypeService = $contentTypeService;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }
@@ -62,7 +60,7 @@ class RelationFieldType extends AbstractType
         $builder->addModelTransformer(new RelationValueTransformer());
     }
 
-    public function finishView(FormView $view, FormInterface $form, array $options)
+    public function finishView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['relations'] = [];
         $view->vars['default_location'] = $options['default_location'];

--- a/src/lib/Form/Type/FieldType/RelationListFieldType.php
+++ b/src/lib/Form/Type/FieldType/RelationListFieldType.php
@@ -26,11 +26,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class RelationListFieldType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ContentService */
-    private $contentService;
+    private ContentService $contentService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
     /**
      * @param \Ibexa\Contracts\Core\Repository\ContentService $contentService
@@ -42,7 +40,7 @@ class RelationListFieldType extends AbstractType
         $this->contentTypeService = $contentTypeService;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }
@@ -62,7 +60,7 @@ class RelationListFieldType extends AbstractType
         $builder->addModelTransformer(new RelationListValueTransformer());
     }
 
-    public function finishView(FormView $view, FormInterface $form, array $options)
+    public function finishView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['relations'] = [];
         $view->vars['default_location'] = $options['default_location'];

--- a/src/lib/Form/Type/FieldType/SelectionFieldType.php
+++ b/src/lib/Form/Type/FieldType/SelectionFieldType.php
@@ -20,7 +20,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class SelectionFieldType extends AbstractType
 {
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/src/lib/Form/Type/FieldType/TextBlockFieldType.php
+++ b/src/lib/Form/Type/FieldType/TextBlockFieldType.php
@@ -22,15 +22,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class TextBlockFieldType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\Repository\FieldTypeService */
-    protected $fieldTypeService;
+    protected FieldTypeService $fieldTypeService;
 
     public function __construct(FieldTypeService $fieldTypeService)
     {
         $this->fieldTypeService = $fieldTypeService;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }
@@ -45,7 +44,7 @@ class TextBlockFieldType extends AbstractType
         return TextareaType::class;
     }
 
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         if (null !== $options['rows']) {
             $view->vars['attr'] = array_merge($view->vars['attr'], ['rows' => $options['rows']]);

--- a/src/lib/Form/Type/FieldType/TextLineFieldType.php
+++ b/src/lib/Form/Type/FieldType/TextLineFieldType.php
@@ -22,15 +22,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class TextLineFieldType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\Repository\FieldTypeService */
-    private $fieldTypeService;
+    private FieldTypeService $fieldTypeService;
 
     public function __construct(FieldTypeService $fieldTypeService)
     {
         $this->fieldTypeService = $fieldTypeService;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }
@@ -50,7 +49,7 @@ class TextLineFieldType extends AbstractType
         $builder->addModelTransformer(new FieldValueTransformer($this->fieldTypeService->getFieldType('ezstring')));
     }
 
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $attributes = [];
 

--- a/src/lib/Form/Type/FieldType/TimeFieldType.php
+++ b/src/lib/Form/Type/FieldType/TimeFieldType.php
@@ -21,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class TimeFieldType extends AbstractType
 {
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }
@@ -42,7 +42,7 @@ class TimeFieldType extends AbstractType
             ->addModelTransformer(new TimeValueTransformer());
     }
 
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['attr']['data-seconds'] = (int) $options['with_seconds'];
     }

--- a/src/lib/Form/Type/FieldType/UrlFieldType.php
+++ b/src/lib/Form/Type/FieldType/UrlFieldType.php
@@ -22,15 +22,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class UrlFieldType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\Repository\FieldTypeService */
-    protected $fieldTypeService;
+    protected FieldTypeService $fieldTypeService;
 
     public function __construct(FieldTypeService $fieldTypeService)
     {
         $this->fieldTypeService = $fieldTypeService;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/src/lib/Form/Type/FieldType/UserAccountFieldType.php
+++ b/src/lib/Form/Type/FieldType/UserAccountFieldType.php
@@ -21,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class UserAccountFieldType extends AbstractType
 {
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/src/lib/Form/Type/LocationType.php
+++ b/src/lib/Form/Type/LocationType.php
@@ -18,8 +18,7 @@ use Symfony\Component\Form\FormView;
 
 class LocationType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\Repository\LocationService */
-    private $locationService;
+    private LocationService $locationService;
 
     /**
      * @param \Ibexa\Contracts\Core\Repository\LocationService $locationService

--- a/src/lib/Form/Type/RelationType.php
+++ b/src/lib/Form/Type/RelationType.php
@@ -69,7 +69,7 @@ final class RelationType extends AbstractType
         FormView $view,
         FormInterface $form,
         array $options
-    ) {
+    ): void {
         $view->vars['destination_location'] = null;
         $value = $form->getData();
 

--- a/src/lib/Form/Type/SwitcherType.php
+++ b/src/lib/Form/Type/SwitcherType.php
@@ -19,7 +19,7 @@ class SwitcherType extends AbstractType
         return CheckboxType::class;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/src/lib/Form/Type/User/BaseUserType.php
+++ b/src/lib/Form/Type/User/BaseUserType.php
@@ -24,7 +24,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class BaseUserType extends AbstractType
 {
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/src/lib/Form/Type/User/UserCreateType.php
+++ b/src/lib/Form/Type/User/UserCreateType.php
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class UserCreateType extends AbstractType
 {
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/src/lib/Form/Type/User/UserUpdateType.php
+++ b/src/lib/Form/Type/User/UserUpdateType.php
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class UserUpdateType extends AbstractType
 {
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/src/lib/Validator/Constraints/FieldTypeValidator.php
+++ b/src/lib/Validator/Constraints/FieldTypeValidator.php
@@ -14,10 +14,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 
 abstract class FieldTypeValidator extends ConstraintValidator
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\FieldTypeService
-     */
-    protected $fieldTypeService;
+    protected FieldTypeService $fieldTypeService;
 
     public function __construct(FieldTypeService $fieldTypeService)
     {

--- a/src/lib/Validator/Constraints/PasswordValidator.php
+++ b/src/lib/Validator/Constraints/PasswordValidator.php
@@ -16,8 +16,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 
 class PasswordValidator extends ConstraintValidator
 {
-    /** @var \Ibexa\Contracts\Core\Repository\UserService */
-    private $userService;
+    private UserService $userService;
 
     /**
      * @param \Ibexa\Contracts\Core\Repository\UserService $userService

--- a/src/lib/Validator/Constraints/UserAccountPasswordValidator.php
+++ b/src/lib/Validator/Constraints/UserAccountPasswordValidator.php
@@ -31,7 +31,7 @@ class UserAccountPasswordValidator extends PasswordValidator
      */
     protected function createValidationErrorsProcessor(): ValidationErrorsProcessor
     {
-        return new ValidationErrorsProcessor($this->context, static function () {
+        return new ValidationErrorsProcessor($this->context, static function (): string {
             return 'password';
         });
     }

--- a/src/lib/Validator/ValidationErrorsProcessor.php
+++ b/src/lib/Validator/ValidationErrorsProcessor.php
@@ -16,8 +16,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  */
 final class ValidationErrorsProcessor
 {
-    /** @var \Symfony\Component\Validator\Context\ExecutionContextInterface */
-    private $context;
+    private ExecutionContextInterface $context;
 
     /** @var callable|null */
     private $propertyPathGenerator;

--- a/tests/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/FieldTypeFormMapperDispatcherPassTest.php
@@ -31,7 +31,7 @@ class FieldTypeFormMapperDispatcherPassTest extends AbstractCompilerPassTestCase
     /**
      * @dataProvider tagsProvider
      */
-    public function testRegisterMappers(string $tag)
+    public function testRegisterMappers(string $tag): void
     {
         $fieldTypeIdentifier = 'field_type_identifier';
         $serviceId = 'service_id';

--- a/tests/lib/Content/Form/Provider/AbstractGroupedContentFormFieldsProviderTest.php
+++ b/tests/lib/Content/Form/Provider/AbstractGroupedContentFormFieldsProviderTest.php
@@ -27,7 +27,7 @@ abstract class AbstractGroupedContentFormFieldsProviderTest extends TestCase
         $mock
             ->expects($matcher)
             ->method('getFieldGroup')
-            ->willReturnCallback(static function () use ($matcher, $expectedGroups) {
+            ->willReturnCallback(static function () use ($matcher, $expectedGroups): string {
                 return $expectedGroups[$matcher->getInvocationCount()];
             });
 

--- a/tests/lib/Content/Form/Provider/GroupedContentFormFieldsProviderTest.php
+++ b/tests/lib/Content/Form/Provider/GroupedContentFormFieldsProviderTest.php
@@ -36,6 +36,6 @@ final class GroupedContentFormFieldsProviderTest extends AbstractGroupedContentF
             ],
         ];
 
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 }

--- a/tests/lib/Content/Form/Provider/IdentifiedGroupedContentFormFieldsProviderTest.php
+++ b/tests/lib/Content/Form/Provider/IdentifiedGroupedContentFormFieldsProviderTest.php
@@ -29,6 +29,6 @@ final class IdentifiedGroupedContentFormFieldsProviderTest extends AbstractGroup
             ],
         ];
 
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 }

--- a/tests/lib/Event/FormActionEventTest.php
+++ b/tests/lib/Event/FormActionEventTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class FormActionEventTest extends TestCase
 {
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $form = $this->createMock(FormInterface::class);
         $data = new stdClass();
@@ -30,7 +30,7 @@ class FormActionEventTest extends TestCase
         self::assertSame($options, $event->getOptions());
     }
 
-    public function testEventDoesntHaveResponse()
+    public function testEventDoesntHaveResponse(): void
     {
         $event = new FormActionEvent(
             $this->createMock(FormInterface::class),
@@ -41,7 +41,7 @@ class FormActionEventTest extends TestCase
         self::assertNull($event->getResponse());
     }
 
-    public function testEventSetResponse()
+    public function testEventSetResponse(): void
     {
         $event = new FormActionEvent(
             $this->createMock(FormInterface::class),
@@ -57,7 +57,7 @@ class FormActionEventTest extends TestCase
         self::assertSame($response, $event->getResponse());
     }
 
-    public function testGetOption()
+    public function testGetOption(): void
     {
         $objectOption = new stdClass();
         $options = ['languageCode' => 'eng-GB', 'foo' => 'bar', 'obj' => $objectOption];

--- a/tests/lib/FieldType/DataTransformer/FieldValueTransformerTest.php
+++ b/tests/lib/FieldType/DataTransformer/FieldValueTransformerTest.php
@@ -16,7 +16,7 @@ use stdClass;
 
 class FieldValueTransformerTest extends TestCase
 {
-    public function testTransformNull()
+    public function testTransformNull(): void
     {
         $value = new stdClass();
 
@@ -30,7 +30,7 @@ class FieldValueTransformerTest extends TestCase
         self::assertNull($result);
     }
 
-    public function testTransform()
+    public function testTransform(): void
     {
         $value = $this->createMock(Value::class);
         $valueHash = ['lorem' => 'Lorem ipsum dolor...'];
@@ -47,7 +47,7 @@ class FieldValueTransformerTest extends TestCase
         self::assertEquals($result, $valueHash);
     }
 
-    public function testReverseTransformNull()
+    public function testReverseTransformNull(): void
     {
         $emptyValue = $this->createMock(Value::class);
 
@@ -65,7 +65,7 @@ class FieldValueTransformerTest extends TestCase
         self::assertSame($emptyValue, $result);
     }
 
-    public function testReverseTransform()
+    public function testReverseTransform(): void
     {
         $value = 'Lorem ipsum dolor...';
         $expected = $this->createMock(Value::class);

--- a/tests/lib/FieldType/DataTransformer/MultiSelectionValueTransformerTest.php
+++ b/tests/lib/FieldType/DataTransformer/MultiSelectionValueTransformerTest.php
@@ -59,7 +59,7 @@ class MultiSelectionValueTransformerTest extends TestCase
     /**
      * @dataProvider transformNullProvider
      */
-    public function testTransformNull(Value|int|bool|array $value): void
+    public function testTransformNull(mixed $value): void
     {
         $transformer = new MultiSelectionValueTransformer();
         self::assertNull($transformer->transform($value));

--- a/tests/lib/FieldType/DataTransformer/MultiSelectionValueTransformerTest.php
+++ b/tests/lib/FieldType/DataTransformer/MultiSelectionValueTransformerTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class MultiSelectionValueTransformerTest extends TestCase
 {
-    public function transformProvider()
+    public function transformProvider(): array
     {
         return [
             [[0]],
@@ -28,7 +28,7 @@ class MultiSelectionValueTransformerTest extends TestCase
     /**
      * @dataProvider transformProvider
      */
-    public function testTransform($valueAsArray)
+    public function testTransform(array $valueAsArray): void
     {
         $transformer = new MultiSelectionValueTransformer();
         $value = new Value($valueAsArray);
@@ -38,14 +38,14 @@ class MultiSelectionValueTransformerTest extends TestCase
     /**
      * @dataProvider transformProvider
      */
-    public function testReverseTransform($valueAsArray)
+    public function testReverseTransform(array $valueAsArray): void
     {
         $transformer = new MultiSelectionValueTransformer();
         $expectedValue = new Value($valueAsArray);
         self::assertEquals($expectedValue, $transformer->reverseTransform($valueAsArray));
     }
 
-    public function transformNullProvider()
+    public function transformNullProvider(): array
     {
         return [
             [new Value()],
@@ -59,13 +59,13 @@ class MultiSelectionValueTransformerTest extends TestCase
     /**
      * @dataProvider transformNullProvider
      */
-    public function testTransformNull($value)
+    public function testTransformNull(Value|int|bool|array $value): void
     {
         $transformer = new MultiSelectionValueTransformer();
         self::assertNull($transformer->transform($value));
     }
 
-    public function testReverseTransformNull()
+    public function testReverseTransformNull(): void
     {
         $transformer = new MultiSelectionValueTransformer();
         self::assertNull($transformer->reverseTransform(null));

--- a/tests/lib/FieldType/DataTransformer/MultipleCountryValueTransformerTest.php
+++ b/tests/lib/FieldType/DataTransformer/MultipleCountryValueTransformerTest.php
@@ -110,7 +110,7 @@ class MultipleCountryValueTransformerTest extends TestCase
     /**
      * @dataProvider reverseTransformNullProvider
      */
-    public function testReverseTransformNull(int|string|Value|null $value): void
+    public function testReverseTransformNull(mixed $value): void
     {
         $transformer = new MultipleCountryValueTransformer($this->countriesInfo);
         self::assertNull($transformer->reverseTransform($value));

--- a/tests/lib/FieldType/DataTransformer/MultipleCountryValueTransformerTest.php
+++ b/tests/lib/FieldType/DataTransformer/MultipleCountryValueTransformerTest.php
@@ -44,7 +44,7 @@ class MultipleCountryValueTransformerTest extends TestCase
         'ZW' => ['Name' => 'Zimbabwe', 'Alpha2' => 'ZW', 'Alpha3' => 'ZWE', 'IDC' => '263'],
     ];
 
-    public function transformProvider()
+    public function transformProvider(): array
     {
         return [
             [[
@@ -61,7 +61,7 @@ class MultipleCountryValueTransformerTest extends TestCase
     /**
      * @dataProvider transformProvider
      */
-    public function testTransform($valueAsArray)
+    public function testTransform(array $valueAsArray): void
     {
         $transformer = new MultipleCountryValueTransformer($this->countriesInfo);
         $value = new Value($valueAsArray);
@@ -71,14 +71,14 @@ class MultipleCountryValueTransformerTest extends TestCase
     /**
      * @dataProvider transformProvider
      */
-    public function testReverseTransform($valueAsArray)
+    public function testReverseTransform(array $valueAsArray): void
     {
         $transformer = new MultipleCountryValueTransformer($this->countriesInfo);
         $expectedValue = new Value($valueAsArray);
         self::assertEquals($expectedValue, $transformer->reverseTransform(array_keys($valueAsArray)));
     }
 
-    public function transformNullProvider()
+    public function transformNullProvider(): array
     {
         return [
             [42],
@@ -91,26 +91,26 @@ class MultipleCountryValueTransformerTest extends TestCase
     /**
      * @dataProvider transformNullProvider
      */
-    public function testTransformNull($value)
+    public function testTransformNull(int|string|array|null $value): void
     {
         $transformer = new MultipleCountryValueTransformer($this->countriesInfo);
         self::assertNull($transformer->transform($value));
     }
 
-    public function reverseTransformNullProvider()
+    public function reverseTransformNullProvider(): array
     {
         return [
             [42],
             ['snafu'],
             [null],
-            [new \Ibexa\Core\FieldType\Country\Value()],
+            [new Value()],
         ];
     }
 
     /**
      * @dataProvider reverseTransformNullProvider
      */
-    public function testReverseTransformNull($value)
+    public function testReverseTransformNull(int|string|Value|null $value): void
     {
         $transformer = new MultipleCountryValueTransformer($this->countriesInfo);
         self::assertNull($transformer->reverseTransform($value));

--- a/tests/lib/FieldType/DataTransformer/RelationListValueTransformerTest.php
+++ b/tests/lib/FieldType/DataTransformer/RelationListValueTransformerTest.php
@@ -17,7 +17,7 @@ final class RelationListValueTransformerTest extends TestCase
     /**
      * @dataProvider dataProviderForTestReverseTransform
      */
-    public function testReverseTransform($value, ?Value $expectedValue): void
+    public function testReverseTransform(?string $value, ?Value $expectedValue): void
     {
         $transformer = new RelationListValueTransformer();
 

--- a/tests/lib/FieldType/DataTransformer/SingleSelectionValueTransformerTest.php
+++ b/tests/lib/FieldType/DataTransformer/SingleSelectionValueTransformerTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class SingleSelectionValueTransformerTest extends TestCase
 {
-    public function transformProvider()
+    public function transformProvider(): array
     {
         return [
             [0],
@@ -26,7 +26,7 @@ class SingleSelectionValueTransformerTest extends TestCase
     /**
      * @dataProvider transformProvider
      */
-    public function testTransform($value)
+    public function testTransform(int $value): void
     {
         $transformer = new SingleSelectionValueTransformer();
         self::assertSame($value, $transformer->transform(new Value([$value])));
@@ -35,14 +35,14 @@ class SingleSelectionValueTransformerTest extends TestCase
     /**
      * @dataProvider transformProvider
      */
-    public function testReverseTransform($value)
+    public function testReverseTransform(int $value): void
     {
         $transformer = new SingleSelectionValueTransformer();
         $expectedValue = new Value([$value]);
         self::assertEquals($expectedValue, $transformer->reverseTransform($value));
     }
 
-    public function transformNullProvider()
+    public function transformNullProvider(): array
     {
         return [
             [new Value()],
@@ -55,13 +55,13 @@ class SingleSelectionValueTransformerTest extends TestCase
     /**
      * @dataProvider transformNullProvider
      */
-    public function testTransformNull($value)
+    public function testTransformNull(Value|bool|string|array $value): void
     {
         $transformer = new SingleSelectionValueTransformer();
         self::assertNull($transformer->transform($value));
     }
 
-    public function testReverseTransformNull()
+    public function testReverseTransformNull(): void
     {
         $transformer = new SingleSelectionValueTransformer();
         self::assertNull($transformer->reverseTransform(null));

--- a/tests/lib/FieldType/DataTransformer/SingleSelectionValueTransformerTest.php
+++ b/tests/lib/FieldType/DataTransformer/SingleSelectionValueTransformerTest.php
@@ -55,7 +55,7 @@ class SingleSelectionValueTransformerTest extends TestCase
     /**
      * @dataProvider transformNullProvider
      */
-    public function testTransformNull(Value|bool|string|array $value): void
+    public function testTransformNull(mixed $value): void
     {
         $transformer = new SingleSelectionValueTransformer();
         self::assertNull($transformer->transform($value));

--- a/tests/lib/FieldType/DataTransformer/TimeValueTransformerTest.php
+++ b/tests/lib/FieldType/DataTransformer/TimeValueTransformerTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 
 class TimeValueTransformerTest extends TestCase
 {
-    public function testTransform()
+    public function testTransform(): void
     {
         $date = new DateTime();
         $value = Value::fromDateTime($date);
@@ -26,7 +26,7 @@ class TimeValueTransformerTest extends TestCase
         self::assertSame($time, $transformer->transform($value));
     }
 
-    public function testTransformZero()
+    public function testTransformZero(): void
     {
         $value = new Value(0);
         $transformer = new TimeValueTransformer();
@@ -34,7 +34,7 @@ class TimeValueTransformerTest extends TestCase
         self::assertSame(0, $transformer->transform($value));
     }
 
-    public function testTransformNull()
+    public function testTransformNull(): void
     {
         $value = new Value(null);
         $transformer = new TimeValueTransformer();
@@ -42,7 +42,7 @@ class TimeValueTransformerTest extends TestCase
         self::assertNull($transformer->transform($value));
     }
 
-    public function testTransformInvalidValue()
+    public function testTransformInvalidValue(): void
     {
         $transformer = new TimeValueTransformer();
 

--- a/tests/lib/FieldType/FieldTypeFormMapperDispatcherTest.php
+++ b/tests/lib/FieldType/FieldTypeFormMapperDispatcherTest.php
@@ -19,11 +19,9 @@ use Symfony\Component\Form\FormInterface;
 
 class FieldTypeFormMapperDispatcherTest extends TestCase
 {
-    /** @var \Ibexa\ContentForms\FieldType\FieldTypeFormMapperDispatcherInterface */
     private FieldTypeFormMapperDispatcher $dispatcher;
 
-    /** @var \Ibexa\Contracts\ContentForms\FieldType\FieldValueFormMapperInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $fieldValueMapperMock;
+    private FieldValueFormMapperInterface & MockObject $fieldValueMapperMock;
 
     protected function setUp(): void
     {

--- a/tests/lib/FieldType/FieldTypeFormMapperDispatcherTest.php
+++ b/tests/lib/FieldType/FieldTypeFormMapperDispatcherTest.php
@@ -13,16 +13,17 @@ use Ibexa\Contracts\ContentForms\Data\Content\FieldData;
 use Ibexa\Contracts\ContentForms\FieldType\FieldValueFormMapperInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Core\Repository\Values\ContentType\FieldDefinition;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\FormInterface;
 
 class FieldTypeFormMapperDispatcherTest extends TestCase
 {
     /** @var \Ibexa\ContentForms\FieldType\FieldTypeFormMapperDispatcherInterface */
-    private $dispatcher;
+    private FieldTypeFormMapperDispatcher $dispatcher;
 
     /** @var \Ibexa\Contracts\ContentForms\FieldType\FieldValueFormMapperInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private $fieldValueMapperMock;
+    private MockObject $fieldValueMapperMock;
 
     protected function setUp(): void
     {
@@ -32,7 +33,7 @@ class FieldTypeFormMapperDispatcherTest extends TestCase
         $this->dispatcher->addMapper($this->fieldValueMapperMock, 'first_type');
     }
 
-    public function testMapFieldValue()
+    public function testMapFieldValue(): void
     {
         $data = new FieldData([
             'field' => new Field(['fieldDefIdentifier' => 'first_type']),

--- a/tests/lib/FieldType/Mapper/UserAccountFieldValueFormMapperTest.php
+++ b/tests/lib/FieldType/Mapper/UserAccountFieldValueFormMapperTest.php
@@ -44,7 +44,7 @@ class UserAccountFieldValueFormMapperTest extends BaseMapperTest
             ->willReturn($userEditForm);
     }
 
-    public function testMapFieldValueFormNoLanguageCode()
+    public function testMapFieldValueFormNoLanguageCode(): void
     {
         $mapper = new UserAccountFieldValueFormMapper();
 
@@ -65,7 +65,7 @@ class UserAccountFieldValueFormMapperTest extends BaseMapperTest
         $mapper->mapFieldValueForm($this->fieldForm, $this->data);
     }
 
-    public function testMapFieldValueFormWithLanguageCode()
+    public function testMapFieldValueFormWithLanguageCode(): void
     {
         $mapper = new UserAccountFieldValueFormMapper();
 

--- a/tests/lib/Validator/Constraints/FieldValueTest.php
+++ b/tests/lib/Validator/Constraints/FieldValueTest.php
@@ -15,19 +15,19 @@ use Symfony\Component\Validator\Constraint;
 
 class FieldValueTest extends TestCase
 {
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $constraint = new FieldValue();
         self::assertSame('ez.field.value', $constraint->message);
     }
 
-    public function testValidatedBy()
+    public function testValidatedBy(): void
     {
         $constraint = new FieldValue();
         self::assertSame(FieldValueValidator::class, $constraint->validatedBy());
     }
 
-    public function testGetTargets()
+    public function testGetTargets(): void
     {
         $constraint = new FieldValue();
         self::assertSame(Constraint::CLASS_CONSTRAINT, $constraint->getTargets());

--- a/tests/lib/Validator/Constraints/PasswordTest.php
+++ b/tests/lib/Validator/Constraints/PasswordTest.php
@@ -15,24 +15,24 @@ use PHPUnit\Framework\TestCase;
 class PasswordTest extends TestCase
 {
     /** @var \Ibexa\ContentForms\Validator\Constraints\Password */
-    private $constraint;
+    private Password $constraint;
 
     protected function setUp(): void
     {
         $this->constraint = new Password();
     }
 
-    public function testConstruct()
+    public function testConstruct(): void
     {
         self::assertSame('ez.user.password.invalid', $this->constraint->message);
     }
 
-    public function testValidatedBy()
+    public function testValidatedBy(): void
     {
         self::assertSame(PasswordValidator::class, $this->constraint->validatedBy());
     }
 
-    public function testGetTargets()
+    public function testGetTargets(): void
     {
         self::assertSame([Password::CLASS_CONSTRAINT, Password::PROPERTY_CONSTRAINT], $this->constraint->getTargets());
     }

--- a/tests/lib/Validator/Constraints/PasswordValidatorTest.php
+++ b/tests/lib/Validator/Constraints/PasswordValidatorTest.php
@@ -21,13 +21,10 @@ use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 class PasswordValidatorTest extends TestCase
 {
-    /** @var \Ibexa\Contracts\Core\Repository\UserService|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $userService;
+    private UserService & MockObject $userService;
 
-    /** @var \Symfony\Component\Validator\Context\ExecutionContextInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $executionContext;
+    private ExecutionContextInterface & MockObject $executionContext;
 
-    /** @var \Ibexa\ContentForms\Validator\Constraints\PasswordValidator */
     private PasswordValidator $validator;
 
     protected function setUp(): void
@@ -41,7 +38,7 @@ class PasswordValidatorTest extends TestCase
     /**
      * @dataProvider dataProviderForValidateNotSupportedValueType
      */
-    public function testValidateShouldBeSkipped(\stdClass|string|null $value): void
+    public function testValidateShouldBeSkipped(mixed $value): void
     {
         $this->userService
             ->expects(self::never())

--- a/tests/lib/Validator/Constraints/PasswordValidatorTest.php
+++ b/tests/lib/Validator/Constraints/PasswordValidatorTest.php
@@ -14,6 +14,7 @@ use Ibexa\Contracts\Core\Repository\UserService;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
 use Ibexa\Contracts\Core\Repository\Values\User\PasswordValidationContext;
 use Ibexa\Core\FieldType\ValidationError;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
@@ -21,13 +22,13 @@ use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 class PasswordValidatorTest extends TestCase
 {
     /** @var \Ibexa\Contracts\Core\Repository\UserService|\PHPUnit\Framework\MockObject\MockObject */
-    private $userService;
+    private MockObject $userService;
 
     /** @var \Symfony\Component\Validator\Context\ExecutionContextInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private $executionContext;
+    private MockObject $executionContext;
 
     /** @var \Ibexa\ContentForms\Validator\Constraints\PasswordValidator */
-    private $validator;
+    private PasswordValidator $validator;
 
     protected function setUp(): void
     {
@@ -40,7 +41,7 @@ class PasswordValidatorTest extends TestCase
     /**
      * @dataProvider dataProviderForValidateNotSupportedValueType
      */
-    public function testValidateShouldBeSkipped($value)
+    public function testValidateShouldBeSkipped(\stdClass|string|null $value): void
     {
         $this->userService
             ->expects(self::never())
@@ -53,7 +54,7 @@ class PasswordValidatorTest extends TestCase
         $this->validator->validate($value, new Password());
     }
 
-    public function testValid()
+    public function testValid(): void
     {
         $password = 'pass';
         $contentType = $this->createMock(ContentType::class);
@@ -61,7 +62,7 @@ class PasswordValidatorTest extends TestCase
         $this->userService
             ->expects(self::once())
             ->method('validatePassword')
-            ->willReturnCallback(function ($actualPassword, $actualContext) use ($password, $contentType) {
+            ->willReturnCallback(function ($actualPassword, $actualContext) use ($password, $contentType): array {
                 $this->assertEquals($password, $actualPassword);
                 $this->assertInstanceOf(PasswordValidationContext::class, $actualContext);
                 $this->assertSame($contentType, $actualContext->contentType);
@@ -78,7 +79,7 @@ class PasswordValidatorTest extends TestCase
         ]));
     }
 
-    public function testInvalid()
+    public function testInvalid(): void
     {
         $contentType = $this->createMock(ContentType::class);
         $password = 'pass';
@@ -88,7 +89,7 @@ class PasswordValidatorTest extends TestCase
         $this->userService
             ->expects(self::once())
             ->method('validatePassword')
-            ->willReturnCallback(function ($actualPassword, $actualContext) use ($password, $contentType, $errorMessage, $errorParameter) {
+            ->willReturnCallback(function ($actualPassword, $actualContext) use ($password, $contentType, $errorMessage, $errorParameter): array {
                 $this->assertEquals($password, $actualPassword);
                 $this->assertInstanceOf(PasswordValidationContext::class, $actualContext);
                 $this->assertSame($contentType, $actualContext->contentType);

--- a/tests/lib/Validator/Constraints/UserAccountPasswordTest.php
+++ b/tests/lib/Validator/Constraints/UserAccountPasswordTest.php
@@ -15,24 +15,24 @@ use PHPUnit\Framework\TestCase;
 class UserAccountPasswordTest extends TestCase
 {
     /** @var \Ibexa\ContentForms\Validator\Constraints\Password */
-    private $constraint;
+    private UserAccountPassword $constraint;
 
     protected function setUp(): void
     {
         $this->constraint = new UserAccountPassword();
     }
 
-    public function testConstruct()
+    public function testConstruct(): void
     {
         self::assertSame('ez.user.password.invalid', $this->constraint->message);
     }
 
-    public function testValidatedBy()
+    public function testValidatedBy(): void
     {
         self::assertSame(UserAccountPasswordValidator::class, $this->constraint->validatedBy());
     }
 
-    public function testGetTargets()
+    public function testGetTargets(): void
     {
         self::assertSame([UserAccountPassword::CLASS_CONSTRAINT, UserAccountPassword::PROPERTY_CONSTRAINT], $this->constraint->getTargets());
     }

--- a/tests/lib/Validator/Constraints/UserAccountPasswordValidatorTest.php
+++ b/tests/lib/Validator/Constraints/UserAccountPasswordValidatorTest.php
@@ -22,19 +22,16 @@ use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 class UserAccountPasswordValidatorTest extends TestCase
 {
-    /** @var \Ibexa\Contracts\Core\Repository\UserService|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $userService;
+    private UserService & MockObject $userService;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\Symfony\Component\Validator\Context\ExecutionContextInterface */
-    private MockObject $executionContext;
+    private ExecutionContextInterface & MockObject $executionContext;
 
-    /** @var \Ibexa\ContentForms\Validator\Constraints\UserAccountPasswordValidator */
     private UserAccountPasswordValidator $validator;
 
     /**
      * @dataProvider dataProviderForValidateNotSupportedValueType
      */
-    public function testValidateShouldBeSkipped(\stdClass|string|null $value): void
+    public function testValidateShouldBeSkipped(mixed $value): void
     {
         $this->userService
             ->expects(self::never())

--- a/tests/lib/Validator/Constraints/UserAccountPasswordValidatorTest.php
+++ b/tests/lib/Validator/Constraints/UserAccountPasswordValidatorTest.php
@@ -15,6 +15,7 @@ use Ibexa\Contracts\Core\Repository\UserService;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
 use Ibexa\Contracts\Core\Repository\Values\User\PasswordValidationContext;
 use Ibexa\Core\FieldType\ValidationError;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
@@ -22,18 +23,18 @@ use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 class UserAccountPasswordValidatorTest extends TestCase
 {
     /** @var \Ibexa\Contracts\Core\Repository\UserService|\PHPUnit\Framework\MockObject\MockObject */
-    private $userService;
+    private MockObject $userService;
 
     /** @var \PHPUnit\Framework\MockObject\MockObject|\Symfony\Component\Validator\Context\ExecutionContextInterface */
-    private $executionContext;
+    private MockObject $executionContext;
 
     /** @var \Ibexa\ContentForms\Validator\Constraints\UserAccountPasswordValidator */
-    private $validator;
+    private UserAccountPasswordValidator $validator;
 
     /**
      * @dataProvider dataProviderForValidateNotSupportedValueType
      */
-    public function testValidateShouldBeSkipped($value)
+    public function testValidateShouldBeSkipped(\stdClass|string|null $value): void
     {
         $this->userService
             ->expects(self::never())
@@ -63,7 +64,7 @@ class UserAccountPasswordValidatorTest extends TestCase
         ];
     }
 
-    public function testValid()
+    public function testValid(): void
     {
         $userAccount = new UserAccountFieldData('user', 'pass', 'user@ibexa.co');
         $contentType = $this->createMock(ContentType::class);
@@ -71,7 +72,7 @@ class UserAccountPasswordValidatorTest extends TestCase
         $this->userService
             ->expects(self::once())
             ->method('validatePassword')
-            ->willReturnCallback(function ($actualPassword, $actualContext) use ($userAccount, $contentType) {
+            ->willReturnCallback(function ($actualPassword, $actualContext) use ($userAccount, $contentType): array {
                 $this->assertEquals($userAccount->password, $actualPassword);
                 $this->assertInstanceOf(PasswordValidationContext::class, $actualContext);
                 $this->assertSame($contentType, $actualContext->contentType);
@@ -88,7 +89,7 @@ class UserAccountPasswordValidatorTest extends TestCase
         ]));
     }
 
-    public function testInvalid()
+    public function testInvalid(): void
     {
         $contentType = $this->createMock(ContentType::class);
         $userAccount = new UserAccountFieldData('user', 'pass', 'user@ibexa.co');
@@ -98,7 +99,7 @@ class UserAccountPasswordValidatorTest extends TestCase
         $this->userService
             ->expects(self::once())
             ->method('validatePassword')
-            ->willReturnCallback(function ($actualPassword, $actualContext) use ($userAccount, $contentType, $errorMessage, $errorParameter) {
+            ->willReturnCallback(function ($actualPassword, $actualContext) use ($userAccount, $contentType, $errorMessage, $errorParameter): array {
                 $this->assertEquals($userAccount->password, $actualPassword);
                 $this->assertInstanceOf(PasswordValidationContext::class, $actualContext);
                 $this->assertSame($contentType, $actualContext->contentType);


### PR DESCRIPTION
> [!CAUTION]
> These changes are volatile and - in some repositories - extensive, so they need to be carefully reviewed before merging.

| :ticket: Issue | IBX-9727 |
|----------------|-----------|

#### Description:

Added missing strict type hints using `\Rector\Set\ValueObject\SetList::TYPE_DECLARATION` set.
Additionally FQCNs have been imported for every affected file using PHP CS Fixer, in some cases they might override unrelated lines.

#### For QA:

Regression tests.
