### PR TITLE
IBX-10056: [Forms] Dispatched field options events in the POST_SET_DATA event

### DIFF
--- a/src/lib/Form/Type/Content/FieldCollectionType.php
+++ b/src/lib/Form/Type/Content/FieldCollectionType.php
@@ -42,7 +42,7 @@ class FieldCollectionType extends CollectionType
     ): void {
         parent::buildForm($builder, $options);
 
-        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($options): void {
+        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) use ($options): void {
             $form = $event->getForm();
             $data = $event->getData();
 


### PR DESCRIPTION
| :ticket: Issue | IBX-10056 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- #83
- https://github.com/ibexa/admin-ui/pull/1547
-->

#### Description:

Similarly as in case of https://github.com/ibexa/admin-ui/pull/1547, we dispatched `\Ibexa\ContentForms\Event\*FieldOptionsEvent` events on `\Symfony\..\FormEvents::PRE_SET_DATA`.

Unfortunately, in Symfony 7, all form fields and their options (including constraints) [are removed via `\Symfony\...\ResizeFormListener`](https://github.com/symfony/symfony/blob/v7.2.1/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php#L110-L112) and re-added again.

In Ibexa Taxonomy, we [add custom field type validators as form config `constraints` options via the mentioned field options event](https://github.com/ibexa/taxonomy/blob/ebcbb3a7e968c60e66eab0efc0891c87d8c54e7f/src/lib/Event/Subscriber/ContentEditCustomValidationSubscriber.php#L136). In order to preserve that configuration, we need to do it in `POST_SET_DATA`.

I have 2 major concerns:
- What else is being done elsewhere via field options events and does it require to be dispatched on pre-set data for different reasons or should it be changed as well?
- We have 30+ usages of PRE_SET_DATA event dispatching. They either don't need this change or there's no Behat coverage.

TODO
- [x] See if both Behat here and regressions pass (or at least do not produce new errors).

#### For QA:

Seems this one might be tricky. There are various forms across the entire system which were customized by PRE_SET_DATA event, so they should be checked, unless we're sure that regressions cover them.

The minimum to test is what has been described in JIRA issue (or maybe for that a passing build is enough).

Please reach out to me directly so maybe we can define some strategy of testing it further.