### PR TITLE
IBX-9727: [Behat] Fixed `ContentTypeCreateStruct` building after strict types changes

### DIFF
--- a/src/lib/Behat/Context/ContentTypeContext.php
+++ b/src/lib/Behat/Context/ContentTypeContext.php
@@ -104,7 +104,7 @@ final class ContentTypeContext extends RawMinkContext implements Context, Snippe
             $struct->mainLanguageCode = 'eng-GB';
         }
 
-        if (!isset($struct->names)) {
+        if (empty($struct->names)) {
             $struct->names = ['eng-GB' => $struct->identifier];
         }
 


### PR DESCRIPTION
>[!CAUTION]
> - [x] Merge https://github.com/ibexa/core/pull/599 first
> - [x] Remove TMP commit before merging


| :ticket: Issue | IBX-9727 |
|----------------|----------|


#### Related PRs: 
- https://github.com/ibexa/core/pull/575
- https://github.com/ibexa/core/pull/599


#### Description:

After ibexa/core#575 changes, `ContentTypeCreateStruct::$names` is always initialized, so we need to change the check done by `\Ibexa\ContentForms\Behat\Context\ContentTypeContext::createContentType`.

Behat failure that uncovered this bug:
```
Ibexa\Core\Base\Exceptions\InvalidArgumentException: Argument '$contentTypeCreateStruct->names' is invalid: At least one name in the main language is required in vendor/ibexa/core/src/lib/Repository/ContentTypeService.php:362
```
#### For QA:
No QA required. Covered by Behat here.

#### Documentation:
Probably Public API fields that had to be initialized with non-null values should be mentioned in the upgrade doc, as the behavior for `isset` slightly changed.