### PR TITLE
Stripped `final` from view extended in AdminUi

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -169,18 +169,6 @@ parameters:
 			path: src/lib/Content/View/Builder/ContentEditViewBuilder.php
 
 		-
-			message: '#^Method Ibexa\\ContentForms\\Content\\View\\ContentEditView\:\:getForm\(\) return type with generic interface Symfony\\Component\\Form\\FormInterface does not specify its types\: TData$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/lib/Content/View/ContentEditView.php
-
-		-
-			message: '#^Method Ibexa\\ContentForms\\Content\\View\\ContentEditView\:\:setForm\(\) has parameter \$form with generic interface Symfony\\Component\\Form\\FormInterface but does not specify its types\: TData$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/lib/Content/View/ContentEditView.php
-
-		-
 			message: '#^Access to protected property Ibexa\\Contracts\\ContentForms\\Data\\Content\\FieldData\:\:\$fieldDefinition\.$#'
 			identifier: property.protected
 			count: 1

--- a/src/lib/Content/View/ContentEditView.php
+++ b/src/lib/Content/View/ContentEditView.php
@@ -16,7 +16,7 @@ use Ibexa\Core\MVC\Symfony\View\ContentValueView;
 use Ibexa\Core\MVC\Symfony\View\LocationValueView;
 use Symfony\Component\Form\FormInterface;
 
-final class ContentEditView extends BaseView implements ContentValueView, LocationValueView
+class ContentEditView extends BaseView implements ContentValueView, LocationValueView
 {
     private Content $content;
 
@@ -57,11 +57,17 @@ final class ContentEditView extends BaseView implements ContentValueView, Locati
         $this->language = $language;
     }
 
+    /**
+     * @return \Symfony\Component\Form\FormInterface<mixed>
+     */
     public function getForm(): FormInterface
     {
         return $this->form;
     }
 
+    /**
+     * @param \Symfony\Component\Form\FormInterface<mixed> $form
+     */
     public function setForm(FormInterface $form): void
     {
         $this->form = $form;


### PR DESCRIPTION
| :ticket: Issue | - |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Followup for https://github.com/ibexa/content-forms/pull/95. It seems, we extend this class in `ibexa/admin-ui` hence reverting marking is as `final`.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
