### PR TITLE
Rollbacked `final` data structs

### DIFF
--- a/src/lib/Data/Content/ContentCreateData.php
+++ b/src/lib/Data/Content/ContentCreateData.php
@@ -15,7 +15,7 @@ use Ibexa\Core\Repository\Values\Content\ContentCreateStruct;
 /**
  * @property \Ibexa\Contracts\ContentForms\Data\Content\FieldData[] $fieldsData
  */
-final class ContentCreateData extends ContentCreateStruct implements NewnessCheckable
+class ContentCreateData extends ContentCreateStruct implements NewnessCheckable
 {
     use ContentData;
 

--- a/src/lib/Data/Content/ContentUpdateData.php
+++ b/src/lib/Data/Content/ContentUpdateData.php
@@ -12,7 +12,7 @@ use Ibexa\ContentForms\Data\NewnessCheckable;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Core\Repository\Values\Content\ContentUpdateStruct;
 
-final class ContentUpdateData extends ContentUpdateStruct implements NewnessCheckable
+class ContentUpdateData extends ContentUpdateStruct implements NewnessCheckable
 {
     use ContentData;
 


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

#### Related PRs: 
https://github.com/ibexa/taxonomy/pull/370

#### Description:
These classes cannot be `final` as they are inherited from in other packages for example https://github.com/ibexa/taxonomy/blob/main/src/lib/Form/Data/TaggedContentCreateData.php

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
