### PR TITLE
IBX-9917: Added event for disabling autosave in content edit form

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1495,6 +1495,12 @@ parameters:
 			path: src/lib/FieldType/Mapper/AuthorFormMapper.php
 
 		-
+			message: '#^Property Ibexa\\ContentForms\\Data\\Content\\ContentUpdateData\:\:\$contentDraft \(Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Content\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: src/lib/FieldType/Mapper/AuthorFormMapper.php
+
+		-
 			message: '#^Method Ibexa\\ContentForms\\FieldType\\Mapper\\BinaryFileFormMapper\:\:mapFieldValueForm\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/src/contracts/Event/AutosaveEnabled.php
+++ b/src/contracts/Event/AutosaveEnabled.php
@@ -9,8 +9,9 @@ declare(strict_types=1);
 namespace Ibexa\Contracts\ContentForms\Event;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
+use Symfony\Contracts\EventDispatcher\Event;
 
-class AutosaveEnabled
+final class AutosaveEnabled extends Event
 {
     private VersionInfo $versionInfo;
 
@@ -31,12 +32,12 @@ class AutosaveEnabled
         return $this->autosaveEnabled;
     }
 
-    public function autosaveEnable(): void
+    public function enableAutosave(): void
     {
         $this->autosaveEnabled = true;
     }
 
-    public function autosaveDisable(): void
+    public function disableAutosave(): void
     {
         $this->autosaveEnabled = false;
     }

--- a/src/contracts/Event/AutosaveEnabled.php
+++ b/src/contracts/Event/AutosaveEnabled.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\ContentForms\Event;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
+
+class AutosaveEnabled
+{
+    private VersionInfo $versionInfo;
+
+    private bool $autosaveEnabled = true;
+
+    public function __construct(VersionInfo $versionInfo)
+    {
+        $this->versionInfo = $versionInfo;
+    }
+
+    public function getVersionInfo(): VersionInfo
+    {
+        return $this->versionInfo;
+    }
+
+    public function isAutosaveEnabled(): bool
+    {
+        return $this->autosaveEnabled;
+    }
+
+    public function autosaveEnable(): void
+    {
+        $this->autosaveEnabled = true;
+    }
+
+    public function autosaveDisable(): void
+    {
+        $this->autosaveEnabled = false;
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | IBX-9917 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/share/pull/129

#### Description:
In my opinion reported phpstan issue (and its new, it wasnt there like two weeks ago) is false positive. There is nothing in 
```php
/**
 * @property \Ibexa\Contracts\ContentForms\Data\Content\FieldData[] $fieldsData
 * @property \Ibexa\Contracts\Core\Repository\Values\Content\Content $contentDraft
 */
class ContentUpdateData extends ContentUpdateStruct implements NewnessCheckable
{
    use ContentData;

    protected $contentDraft;

    public function isNew()
    {
        return false;
    }
}
```
that guarantess that `$contentDraft` is not null, unless I am not seeing something. That `@property` annotation is missleading as we seen in the past many times before when dealing with our VO.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
