### PR TITLE
IBX-10978: Added tel/mailto options to urlType

### DIFF
--- a/src/lib/Form/EventSubscriber/FixUrlProtocolListener.php
+++ b/src/lib/Form/EventSubscriber/FixUrlProtocolListener.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\ContentForms\Form\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+class FixUrlProtocolListener implements EventSubscriberInterface
+{
+    private $defaultProtocol;
+
+    /**
+     * @param string|null $defaultProtocol The URL scheme to add when there is none or null to not modify the data
+     */
+    public function __construct(?string $defaultProtocol = 'http')
+    {
+        $this->defaultProtocol = $defaultProtocol;
+    }
+
+    public function onSubmit(FormEvent $event)
+    {
+        $data = $event->getData();
+        if (null === $this->defaultProtocol || empty($data) || !\is_string($data)) {
+            return;
+        }
+
+        $protocol = explode(':', $data)[0];
+        if ($this->hasAuthority($protocol) && preg_match('~^(?:[/.]|[\w+.-]+://|[^:/?@#]++@)~', $data)) {
+            return;
+        }
+
+        if (!$this->hasAuthority($protocol) && preg_match('~^(?:[/.]|[\w+.-]+:|[^:/?@#]++@)~', $data)) {
+            return;
+        }
+
+        $schemaSeparator = $this->hasAuthority($this->defaultProtocol) ? '://' : ':';
+        if (!preg_match('~^(?:[/.]|[\w+.-]+' . $schemaSeparator . '|[^:/?@#]++@)~', $data)) {
+            $event->setData($this->defaultProtocol . $schemaSeparator . $data);
+        }
+    }
+
+    private function hasAuthority($protocol)
+    {
+        return in_array($protocol, ['mailto', 'tel']) ? false : true;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [FormEvents::SUBMIT => 'onSubmit'];
+    }
+}

--- a/src/lib/Form/EventSubscriber/FixUrlProtocolListener.php
+++ b/src/lib/Form/EventSubscriber/FixUrlProtocolListener.php
@@ -18,7 +18,7 @@ class FixUrlProtocolListener implements EventSubscriberInterface
     /** @var string|null */
     private $defaultProtocol;
 
-    /** @var Symfony\Component\Form\Extension\Core\EventListener\FixUrlProtocolListener */
+    /** @var \Symfony\Component\Form\Extension\Core\EventListener\FixUrlProtocolListener */
     private $fixUrlProtocolListener;
 
     /**
@@ -34,16 +34,17 @@ class FixUrlProtocolListener implements EventSubscriberInterface
     {
         $data = $event->getData();
         $dataLink = $data['link'] ?? null;
-        if (is_null($this->defaultProtocol) || empty($data) || empty($dataLink) || !\is_string($dataLink)){
+        if (null === $this->defaultProtocol || empty($data) || empty($dataLink) || !\is_string($dataLink)) {
             return;
         }
-        
+
         $protocol = explode(':', $dataLink)[0];
         if ($this->hasAuthority($protocol) && $this->hasAuthority($this->defaultProtocol)) {
             $event->setData($dataLink);
             $this->fixUrlProtocolListener->onSubmit($event);
             $data['link'] = $event->getData();
             $event->setData($data);
+
             return;
         }
 
@@ -52,8 +53,8 @@ class FixUrlProtocolListener implements EventSubscriberInterface
         }
 
         $schemaSeparator = $this->hasAuthority($this->defaultProtocol) ? '://' : ':';
-        if (!preg_match('~^(?:[/.]|[\w+.-]+'. $schemaSeparator. '|[^:/?@#]++@)~', $dataLink)) {
-            $data['link'] = $this->defaultProtocol. $schemaSeparator. $dataLink;
+        if (!preg_match('~^(?:[/.]|[\w+.-]+' . $schemaSeparator . '|[^:/?@#]++@)~', $dataLink)) {
+            $data['link'] = $this->defaultProtocol . $schemaSeparator . $dataLink;
             $event->setData($data);
         }
     }

--- a/src/lib/Form/EventSubscriber/FixUrlProtocolListener.php
+++ b/src/lib/Form/EventSubscriber/FixUrlProtocolListener.php
@@ -14,6 +14,7 @@ use Symfony\Component\Form\FormEvents;
 
 class FixUrlProtocolListener implements EventSubscriberInterface
 {
+    /** @var string|null */
     private $defaultProtocol;
 
     /**
@@ -24,7 +25,7 @@ class FixUrlProtocolListener implements EventSubscriberInterface
         $this->defaultProtocol = $defaultProtocol;
     }
 
-    public function onSubmit(FormEvent $event)
+    public function onSubmit(FormEvent $event): void
     {
         $data = $event->getData();
         if (null === $this->defaultProtocol || empty($data) || !\is_string($data)) {
@@ -46,12 +47,12 @@ class FixUrlProtocolListener implements EventSubscriberInterface
         }
     }
 
-    private function hasAuthority($protocol)
+    private function hasAuthority(string $protocol): bool
     {
         return in_array($protocol, ['mailto', 'tel']) ? false : true;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [FormEvents::SUBMIT => 'onSubmit'];
     }

--- a/src/lib/Form/EventSubscriber/FixUrlProtocolListener.php
+++ b/src/lib/Form/EventSubscriber/FixUrlProtocolListener.php
@@ -68,7 +68,7 @@ class FixUrlProtocolListener implements EventSubscriberInterface
 
     private function hasAuthority(string $protocol): bool
     {
-        return in_array($protocol, ['mailto', 'tel']) ? false : true;
+        return !in_array($protocol, ['mailto', 'tel']);
     }
 
     public static function getSubscribedEvents(): array

--- a/src/lib/Form/EventSubscriber/FixUrlProtocolListener.php
+++ b/src/lib/Form/EventSubscriber/FixUrlProtocolListener.php
@@ -52,8 +52,15 @@ class FixUrlProtocolListener implements EventSubscriberInterface
             return;
         }
 
-        $schemaSeparator = $this->hasAuthority($this->defaultProtocol) ? '://' : ':';
-        if (!preg_match('~^(?:[/.]|[\w+.-]+' . $schemaSeparator . '|[^:/?@#]++@)~', $dataLink)) {
+        if ($this->hasAuthority($this->defaultProtocol)) {
+            $schemaSeparator = '://';
+            $regExp = '~^(?:[/.]|[\w+.-]+//|[^:/?@#]++@)~';
+        } else {
+            $schemaSeparator = ':';
+            $regExp = '~^[\w+.-]+:~'; // allowing emails for non-http/https/file
+        }
+
+        if (!preg_match($regExp, $dataLink)) {
             $data['link'] = $this->defaultProtocol . $schemaSeparator . $dataLink;
             $event->setData($data);
         }

--- a/src/lib/Form/EventSubscriber/FixUrlProtocolListener.php
+++ b/src/lib/Form/EventSubscriber/FixUrlProtocolListener.php
@@ -13,7 +13,10 @@ use Symfony\Component\Form\Extension\Core\EventListener\FixUrlProtocolListener a
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 
-class FixUrlProtocolListener implements EventSubscriberInterface
+/**
+ * @internal
+ */
+final class FixUrlProtocolListener implements EventSubscriberInterface
 {
     /** @var string|null */
     private $defaultProtocol;
@@ -68,7 +71,7 @@ class FixUrlProtocolListener implements EventSubscriberInterface
 
     private function hasAuthority(string $protocol): bool
     {
-        return !in_array($protocol, ['mailto', 'tel']);
+        return !in_array($protocol, ['mailto', 'tel'], true);
     }
 
     public static function getSubscribedEvents(): array

--- a/src/lib/Form/EventSubscriber/FixUrlProtocolListener.php
+++ b/src/lib/Form/EventSubscriber/FixUrlProtocolListener.php
@@ -34,22 +34,18 @@ final class FixUrlProtocolListener implements EventSubscriberInterface
     public function onSubmit(FormEvent $event): void
     {
         $data = $event->getData();
-        $dataLink = $data['link'] ?? null;
-        if (null === $this->defaultProtocol || empty($data) || empty($dataLink) || !\is_string($dataLink)) {
+        if (null === $this->defaultProtocol || empty($data) || !\is_string($data)) {
             return;
         }
 
-        $protocol = explode(':', $dataLink)[0];
+        $protocol = explode(':', $data)[0];
         if ($this->hasAuthority($protocol) && $this->hasAuthority($this->defaultProtocol)) {
-            $event->setData($dataLink);
             $this->fixUrlProtocolListener->onSubmit($event);
-            $data['link'] = $event->getData();
-            $event->setData($data);
 
             return;
         }
 
-        if (!$this->hasAuthority($protocol) && preg_match('~^(?:[/.]|[\w+.-]+:|[^:/?@#]++@)~', $dataLink)) {
+        if (!$this->hasAuthority($protocol) && preg_match('~^(?:[/.]|[\w+.-]+:|[^:/?@#]++@)~', $data)) {
             return;
         }
 
@@ -61,9 +57,8 @@ final class FixUrlProtocolListener implements EventSubscriberInterface
             $regExp = '~^[\w+.-]+:~'; // allowing emails for non-http/https/file
         }
 
-        if (!preg_match($regExp, $dataLink)) {
-            $data['link'] = $this->defaultProtocol . $schemaSeparator . $dataLink;
-            $event->setData($data);
+        if (!preg_match($regExp, $data)) {
+            $event->setData($this->defaultProtocol . $schemaSeparator . $data);
         }
     }
 

--- a/src/lib/Form/EventSubscriber/FixUrlProtocolListener.php
+++ b/src/lib/Form/EventSubscriber/FixUrlProtocolListener.php
@@ -38,7 +38,7 @@ final class FixUrlProtocolListener implements EventSubscriberInterface
             return;
         }
 
-        $protocol = explode(':', $data)[0];
+        $protocol = explode(':', $data, 2)[0];
         if ($this->hasAuthority($protocol) && $this->hasAuthority($this->defaultProtocol)) {
             $this->fixUrlProtocolListener->onSubmit($event);
 

--- a/src/lib/Form/EventSubscriber/FixUrlProtocolListener.php
+++ b/src/lib/Form/EventSubscriber/FixUrlProtocolListener.php
@@ -18,11 +18,9 @@ use Symfony\Component\Form\FormEvents;
  */
 final class FixUrlProtocolListener implements EventSubscriberInterface
 {
-    /** @var string|null */
-    private $defaultProtocol;
+    private ?string $defaultProtocol;
 
-    /** @var \Symfony\Component\Form\Extension\Core\EventListener\FixUrlProtocolListener */
-    private $fixUrlProtocolListener;
+    private BaseFixUrlProtocolListener $fixUrlProtocolListener;
 
     /**
      * @param string|null $defaultProtocol The URL scheme to add when there is none or null to not modify the data

--- a/src/lib/Form/Type/FieldType/UrlFieldType.php
+++ b/src/lib/Form/Type/FieldType/UrlFieldType.php
@@ -49,8 +49,10 @@ class UrlFieldType extends AbstractType
                 [
                     'label' => /** @Desc("URL") */ 'content.field_type.ezurl.link',
                     'required' => $options['required'],
+                    'default_protocol' => null,
                 ]
             )
+            ->addEventSubscriber(new FixUrlProtocolListener())
             ->add(
                 'text',
                 TextType::class,

--- a/src/lib/Form/Type/FieldType/UrlFieldType.php
+++ b/src/lib/Form/Type/FieldType/UrlFieldType.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\ContentForms\Form\Type\FieldType;
 
 use Ibexa\ContentForms\FieldType\DataTransformer\FieldValueTransformer;
+use Ibexa\ContentForms\Form\EventSubscriber\FixUrlProtocolListener;
 use Ibexa\Contracts\Core\Repository\FieldTypeService;
 use JMS\TranslationBundle\Annotation\Desc;
 use Symfony\Component\Form\AbstractType;

--- a/src/lib/Form/Type/FieldType/UrlFieldType.php
+++ b/src/lib/Form/Type/FieldType/UrlFieldType.php
@@ -53,7 +53,6 @@ class UrlFieldType extends AbstractType
                     'default_protocol' => null,
                 ]
             )
-            ->addEventSubscriber(new FixUrlProtocolListener())
             ->add(
                 'text',
                 TextType::class,
@@ -63,6 +62,8 @@ class UrlFieldType extends AbstractType
                 ]
             )
             ->addModelTransformer(new FieldValueTransformer($this->fieldTypeService->getFieldType('ezurl')));
+
+        $builder->get('link')->addEventSubscriber(new FixUrlProtocolListener());
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/tests/lib/Form/EventSubscriber/FixUrlProtocolListenerTest.php
+++ b/tests/lib/Form/EventSubscriber/FixUrlProtocolListenerTest.php
@@ -15,6 +15,16 @@ use Symfony\Component\Form\FormInterface;
 
 final class FixUrlProtocolListenerTest extends TestCase
 {
+    private const DOMAIN = 'example.com';
+    private const MAIL = 'foo@' . self::DOMAIN;
+    private const TEL = '+123456';
+    private const URL_HTTP = 'http://' . self::DOMAIN;
+    private const URL_HTTPS = 'https://' . self::DOMAIN;
+    private const URL_MAILTO = 'mailto:' . self::MAIL;
+    private const URL_RELATIVE = '/foo/bar/';
+    private const URL_SFTP = 'sftp://' . self::DOMAIN;
+    private const URL_TEL = 'tel:' . self::TEL;
+
     /**
      * @dataProvider provideUrlCases
      *
@@ -43,49 +53,49 @@ final class FixUrlProtocolListenerTest extends TestCase
     public static function provideUrlCases(): iterable
     {
         yield 'adds http when protocol missing' => [
-            ['link' => 'example1.com'],
-            ['link' => 'http://example1.com'],
+            ['link' => self::DOMAIN],
+            ['link' => self::URL_HTTP],
         ];
 
         yield 'does not modify https url' => [
-            ['link' => 'https://example2.com'],
-            ['link' => 'https://example2.com'],
+            ['link' => self::URL_HTTPS],
+            ['link' => self::URL_HTTPS],
         ];
 
         yield 'does not modify http url' => [
-            ['link' => 'http://example3.com'],
-            ['link' => 'http://example3.com'],
+            ['link' => self::URL_HTTP],
+            ['link' => self::URL_HTTP],
         ];
 
         yield 'keep relative url with leading / intact' => [
-            ['link' => '/foo/bar'],
-            ['link' => '/foo/bar'],
+            ['link' => self::URL_RELATIVE],
+            ['link' => self::URL_RELATIVE],
         ];
 
         yield 'keeps ftp intact' => [
-            ['link' => 'ftp://example4.com'],
-            ['link' => 'ftp://example4.com'],
+            ['link' => self::URL_SFTP],
+            ['link' => self::URL_SFTP],
         ];
 
         yield 'keeps tel intact' => [
-            ['link' => 'tel:+123456'],
-            ['link' => 'tel:+123456'],
+            ['link' => self::URL_TEL],
+            ['link' => self::URL_TEL],
         ];
 
         yield 'adds default tel' => [
-            ['link' => '+123456'],
-            ['link' => 'tel:+123456'],
+            ['link' => self::TEL],
+            ['link' => self::URL_TEL],
             'tel',
         ];
 
         yield 'keeps mailto intact' => [
-            ['link' => 'mailto:foo@home.com'],
-            ['link' => 'mailto:foo@home.com'],
+            ['link' => self::URL_MAILTO],
+            ['link' => self::URL_MAILTO],
         ];
 
         yield 'adds default mailto' => [
-            ['link' => 'bar@home'],
-            ['link' => 'mailto:bar@home'],
+            ['link' => self::MAIL],
+            ['link' => self::URL_MAILTO],
             'mailto',
         ];
 

--- a/tests/lib/Form/EventSubscriber/FixUrlProtocolListenerTest.php
+++ b/tests/lib/Form/EventSubscriber/FixUrlProtocolListenerTest.php
@@ -57,6 +57,11 @@ final class FixUrlProtocolListenerTest extends TestCase
             ['link' => 'http://example.com'],
         ];
 
+        yield 'keep relative url with leading / intact' => [
+            ['link' => '/foo/bar'],
+            ['link' => '/foo/bar'],
+        ];
+
         yield 'keeps ftp intact' => [
             ['link' => 'ftp://example.com'],
             ['link' => 'ftp://example.com'],
@@ -73,9 +78,14 @@ final class FixUrlProtocolListenerTest extends TestCase
             'tel',
         ];
 
+        yield 'keeps mailto intact' => [
+            ['link' => 'mailto:me@home.com'],
+            ['link' => 'mailto:me@home.com'],
+        ];
+
         yield 'adds default mailto' => [
-            ['link' => 'me@home.de'],
-            ['link' => 'mailto:me@home.de'],
+            ['link' => 'me@home'],
+            ['link' => 'mailto:me@home'],
             'mailto',
         ];
 

--- a/tests/lib/Form/EventSubscriber/FixUrlProtocolListenerTest.php
+++ b/tests/lib/Form/EventSubscriber/FixUrlProtocolListenerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\ContentForms\Form\EventSubscriber;
+
+use Ibexa\ContentForms\Form\EventSubscriber\FixUrlProtocolListener;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormInterface;
+
+final class FixUrlProtocolListenerTest extends TestCase
+{
+    /**
+     * @dataProvider provideUrlCases
+     *
+     * @param array<string, string>|null $inputData
+     * @param array<string, string>|null $expectedData
+     * @param string $defaultProtocol
+     */
+    public function testUrlProtocolHandling(?array $inputData, ?array $expectedData, ?string $defaultProtocol = 'http'): void
+    {
+        $form = $this->createMock(FormInterface::class);
+        $listener = new FixUrlProtocolListener($defaultProtocol);
+
+        $event = new FormEvent($form, $inputData);
+
+        $listener->onSubmit($event);
+
+        self::assertSame($expectedData, $event->getData());
+    }
+
+    /**
+     * @return iterable<string, array{
+     *     0: array<string, string>|null,
+     *     1: array<string, string>|null
+     * }>
+     */
+    public static function provideUrlCases(): iterable
+    {
+        yield 'adds http when protocol missing' => [
+            ['link' => 'example.com'],
+            ['link' => 'http://example.com'],
+        ];
+
+        yield 'does not modify https url' => [
+            ['link' => 'https://example.com'],
+            ['link' => 'https://example.com'],
+        ];
+
+        yield 'does not modify http url' => [
+            ['link' => 'http://example.com'],
+            ['link' => 'http://example.com'],
+        ];
+
+        yield 'keeps ftp intact' => [
+            ['link' => 'ftp://example.com'],
+            ['link' => 'ftp://example.com'],
+        ];
+
+        yield 'keeps tel intact' => [
+            ['link' => 'tel:+123456'],
+            ['link' => 'tel:+123456'],
+        ];
+
+        yield 'adds default tel' => [
+            ['link' => '+123456'],
+            ['link' => 'tel:+123456'],
+            'tel',
+        ];
+
+        yield 'adds default mailto' => [
+            ['link' => 'me@home.de'],
+            ['link' => 'mailto:me@home.de'],
+            'mailto',
+        ];
+
+        yield 'does nothing when link is empty string' => [
+            ['link' => ''],
+            ['link' => ''],
+        ];
+
+        yield 'does nothing when link key is missing' => [
+            [],
+            [],
+        ];
+
+        yield 'does nothing when data is null' => [
+            null,
+            null,
+        ];
+    }
+}

--- a/tests/lib/Form/EventSubscriber/FixUrlProtocolListenerTest.php
+++ b/tests/lib/Form/EventSubscriber/FixUrlProtocolListenerTest.php
@@ -43,18 +43,18 @@ final class FixUrlProtocolListenerTest extends TestCase
     public static function provideUrlCases(): iterable
     {
         yield 'adds http when protocol missing' => [
-            ['link' => 'example.com'],
-            ['link' => 'http://example.com'],
+            ['link' => 'example1.com'],
+            ['link' => 'http://example1.com'],
         ];
 
         yield 'does not modify https url' => [
-            ['link' => 'https://example.com'],
-            ['link' => 'https://example.com'],
+            ['link' => 'https://example2.com'],
+            ['link' => 'https://example2.com'],
         ];
 
         yield 'does not modify http url' => [
-            ['link' => 'http://example.com'],
-            ['link' => 'http://example.com'],
+            ['link' => 'http://example3.com'],
+            ['link' => 'http://example3.com'],
         ];
 
         yield 'keep relative url with leading / intact' => [
@@ -63,8 +63,8 @@ final class FixUrlProtocolListenerTest extends TestCase
         ];
 
         yield 'keeps ftp intact' => [
-            ['link' => 'ftp://example.com'],
-            ['link' => 'ftp://example.com'],
+            ['link' => 'ftp://example4.com'],
+            ['link' => 'ftp://example4.com'],
         ];
 
         yield 'keeps tel intact' => [
@@ -79,13 +79,13 @@ final class FixUrlProtocolListenerTest extends TestCase
         ];
 
         yield 'keeps mailto intact' => [
-            ['link' => 'mailto:me@home.com'],
-            ['link' => 'mailto:me@home.com'],
+            ['link' => 'mailto:foo@home.com'],
+            ['link' => 'mailto:foo@home.com'],
         ];
 
         yield 'adds default mailto' => [
-            ['link' => 'me@home'],
-            ['link' => 'mailto:me@home'],
+            ['link' => 'bar@home'],
+            ['link' => 'mailto:bar@home'],
             'mailto',
         ];
 

--- a/tests/lib/Form/EventSubscriber/FixUrlProtocolListenerTest.php
+++ b/tests/lib/Form/EventSubscriber/FixUrlProtocolListenerTest.php
@@ -52,66 +52,57 @@ final class FixUrlProtocolListenerTest extends TestCase
      */
     public static function provideUrlCases(): iterable
     {
-        yield 'adds http when protocol missing' => [
-            ['link' => self::DOMAIN],
-            ['link' => self::URL_HTTP],
-        ];
-
-        yield 'does not modify https url' => [
-            ['link' => self::URL_HTTPS],
-            ['link' => self::URL_HTTPS],
-        ];
-
-        yield 'does not modify http url' => [
-            ['link' => self::URL_HTTP],
-            ['link' => self::URL_HTTP],
-        ];
-
-        yield 'keep relative url with leading / intact' => [
-            ['link' => self::URL_RELATIVE],
-            ['link' => self::URL_RELATIVE],
-        ];
-
-        yield 'keeps ftp intact' => [
-            ['link' => self::URL_SFTP],
-            ['link' => self::URL_SFTP],
-        ];
-
-        yield 'keeps tel intact' => [
-            ['link' => self::URL_TEL],
-            ['link' => self::URL_TEL],
-        ];
-
-        yield 'adds default tel' => [
-            ['link' => self::TEL],
-            ['link' => self::URL_TEL],
-            'tel',
-        ];
-
-        yield 'keeps mailto intact' => [
-            ['link' => self::URL_MAILTO],
-            ['link' => self::URL_MAILTO],
-        ];
-
-        yield 'adds default mailto' => [
-            ['link' => self::MAIL],
-            ['link' => self::URL_MAILTO],
-            'mailto',
-        ];
-
-        yield 'does nothing when link is empty string' => [
-            ['link' => ''],
-            ['link' => ''],
-        ];
-
-        yield 'does nothing when link key is missing' => [
-            [],
-            [],
-        ];
-
-        yield 'does nothing when data is null' => [
-            null,
-            null,
+        return [
+            'adds http when protocol missing' => [
+                ['link' => self::DOMAIN],
+                ['link' => self::URL_HTTP],
+            ],
+            'does not modify https url' => [
+                ['link' => self::URL_HTTPS],
+                ['link' => self::URL_HTTPS],
+            ],
+            'does not modify http url' => [
+                ['link' => self::URL_HTTP],
+                ['link' => self::URL_HTTP],
+            ],
+            'keep relative url with leading / intact' => [
+                ['link' => self::URL_RELATIVE],
+                ['link' => self::URL_RELATIVE],
+            ],
+            'keeps ftp intact' => [
+                ['link' => self::URL_SFTP],
+                ['link' => self::URL_SFTP],
+            ],
+            'keeps tel intact' => [
+                ['link' => self::URL_TEL],
+                ['link' => self::URL_TEL],
+            ],
+            'adds default tel' => [
+                ['link' => self::TEL],
+                ['link' => self::URL_TEL],
+                'tel',
+            ],
+            'keeps mailto intact' => [
+                ['link' => self::URL_MAILTO],
+                ['link' => self::URL_MAILTO],
+            ],
+            'adds default mailto' => [
+                ['link' => self::MAIL],
+                ['link' => self::URL_MAILTO],
+                'mailto',
+            ],
+            'does nothing when link is empty string' => [
+                ['link' => ''],
+                ['link' => ''],
+            ],
+            'does nothing when link key is missing' => [
+                [],
+                [],
+            ],
+            'does nothing when data is null' => [
+                null,
+                null,
+            ],
         ];
     }
 }

--- a/tests/lib/Form/EventSubscriber/FixUrlProtocolListenerTest.php
+++ b/tests/lib/Form/EventSubscriber/FixUrlProtocolListenerTest.php
@@ -28,11 +28,11 @@ final class FixUrlProtocolListenerTest extends TestCase
     /**
      * @dataProvider provideUrlCases
      *
-     * @param array<string, string>|null $inputData
-     * @param array<string, string>|null $expectedData
+     * @param string|null $inputData
+     * @param string|null $expectedData
      * @param string $defaultProtocol
      */
-    public function testUrlProtocolHandling(?array $inputData, ?array $expectedData, ?string $defaultProtocol = 'http'): void
+    public function testUrlProtocolHandling(?string $inputData, ?string $expectedData, ?string $defaultProtocol = 'http'): void
     {
         $form = $this->createMock(FormInterface::class);
         $listener = new FixUrlProtocolListener($defaultProtocol);
@@ -46,58 +46,54 @@ final class FixUrlProtocolListenerTest extends TestCase
 
     /**
      * @return iterable<string, array{
-     *     0: array<string, string>|null,
-     *     1: array<string, string>|null
+     *     0: string|null,
+     *     1: string|null
      * }>
      */
     public static function provideUrlCases(): iterable
     {
         return [
             'adds http when protocol missing' => [
-                ['link' => self::DOMAIN],
-                ['link' => self::URL_HTTP],
+                self::DOMAIN,
+                self::URL_HTTP,
             ],
             'does not modify https url' => [
-                ['link' => self::URL_HTTPS],
-                ['link' => self::URL_HTTPS],
+                self::URL_HTTPS,
+                self::URL_HTTPS,
             ],
             'does not modify http url' => [
-                ['link' => self::URL_HTTP],
-                ['link' => self::URL_HTTP],
+                self::URL_HTTP,
+                self::URL_HTTP,
             ],
             'keep relative url with leading / intact' => [
-                ['link' => self::URL_RELATIVE],
-                ['link' => self::URL_RELATIVE],
+                self::URL_RELATIVE,
+                self::URL_RELATIVE,
             ],
             'keeps ftp intact' => [
-                ['link' => self::URL_SFTP],
-                ['link' => self::URL_SFTP],
+                self::URL_SFTP,
+                self::URL_SFTP,
             ],
             'keeps tel intact' => [
-                ['link' => self::URL_TEL],
-                ['link' => self::URL_TEL],
+                self::URL_TEL,
+                self::URL_TEL,
             ],
             'adds default tel' => [
-                ['link' => self::TEL],
-                ['link' => self::URL_TEL],
+                self::TEL,
+                self::URL_TEL,
                 'tel',
             ],
             'keeps mailto intact' => [
-                ['link' => self::URL_MAILTO],
-                ['link' => self::URL_MAILTO],
+                self::URL_MAILTO,
+                self::URL_MAILTO,
             ],
             'adds default mailto' => [
-                ['link' => self::MAIL],
-                ['link' => self::URL_MAILTO],
+                self::MAIL,
+                self::URL_MAILTO,
                 'mailto',
             ],
             'does nothing when link is empty string' => [
-                ['link' => ''],
-                ['link' => ''],
-            ],
-            'does nothing when link key is missing' => [
-                [],
-                [],
+                '',
+                '',
             ],
             'does nothing when data is null' => [
                 null,

--- a/tests/lib/Form/EventSubscriber/FixUrlProtocolListenerTest.php
+++ b/tests/lib/Form/EventSubscriber/FixUrlProtocolListenerTest.php
@@ -27,12 +27,8 @@ final class FixUrlProtocolListenerTest extends TestCase
 
     /**
      * @dataProvider provideUrlCases
-     *
-     * @param string|null $inputData
-     * @param string|null $expectedData
-     * @param string $defaultProtocol
      */
-    public function testUrlProtocolHandling(?string $inputData, ?string $expectedData, ?string $defaultProtocol = 'http'): void
+    public function testUrlProtocolHandling(?string $inputData, ?string $expectedData, string $defaultProtocol = 'http'): void
     {
         $form = $this->createMock(FormInterface::class);
         $listener = new FixUrlProtocolListener($defaultProtocol);
@@ -47,7 +43,8 @@ final class FixUrlProtocolListenerTest extends TestCase
     /**
      * @return iterable<string, array{
      *     0: string|null,
-     *     1: string|null
+     *     1: string|null,
+     *     2?: string
      * }>
      */
     public static function provideUrlCases(): iterable


### PR DESCRIPTION
| :ticket: Issue | IBX-10978|
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/admin-ui/pull/1813

#### Description:
PR disables Symfony's `FixUrlProtocolListener` and introduces a custom `FixUrlProtocolListener`.
Symfony's `FixUrlProtocolListener` considers URLs like `tel:123456` (without `//`) as having no protocol.
Those URLs will wrongly be prefixed with `http://`.
(Technically URLs like  `tel:123456` are valid).

Own implementation fixes this behavior. 
For now only `tel` and `mailto` are added as allowed scheme - further improvement could make this part more flexible via config,

Reference for URL syntax:
https://en.wikipedia.org/wiki/URL#Syntax

#### For QA:
Needs to be tested together with https://github.com/ibexa/admin-ui/pull/1813
