### PR TITLE
IBX-11766: Replaced phpunit assertions with webmozart equivalents

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,11 @@
         "ibexa/rest": "~5.0.x-dev",
         "ibexa/test-core": "~5.0.x-dev",
         "matthiasnoback/symfony-dependency-injection-test": "^5.0",
-        "phpunit/phpunit": "^9.6",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
-        "phpstan/phpstan-symfony": "^2.0"
+        "phpstan/phpstan-symfony": "^2.0",
+        "phpunit/phpunit": "^9.6",
+        "webmozart/assert": "^2.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -433,7 +433,7 @@ parameters:
 			path: src/lib/Form/Type/FieldType/AuthorFieldType.php
 
 		-
-			message: '#^Method Ibexa\\ContentForms\\Form\\Type\\FieldType\\AuthorFieldType\:\:getViewTransformer\(\) return type with generic interface Symfony\\Component\\Form\\DataTransformerInterface does not specify its types\: T, R$#'
+			message: '#^Method Ibexa\\ContentForms\\Form\\Type\\FieldType\\AuthorFieldType\:\:getViewTransformer\(\) return type with generic interface Symfony\\Component\\Form\\DataTransformerInterface does not specify its types\: TValue, TTransformedValue$#'
 			identifier: missingType.generics
 			count: 1
 			path: src/lib/Form/Type/FieldType/AuthorFieldType.php

--- a/src/lib/Behat/Context/ContentTypeContext.php
+++ b/src/lib/Behat/Context/ContentTypeContext.php
@@ -18,6 +18,7 @@ use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeCreateStruct;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinitionUpdateStruct;
 use Ibexa\Core\Repository\Values\User\UserReference;
+use RuntimeException;
 use Webmozart\Assert\Assert as Assertion;
 
 final class ContentTypeContext extends RawMinkContext implements Context, SnippetAcceptingContext
@@ -40,7 +41,7 @@ final class ContentTypeContext extends RawMinkContext implements Context, Snippe
             $contentType = $this->contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
             Assertion::eq($contentType->id, $id);
         } catch (NotFoundException) {
-            throw new \RuntimeException("No ContentType with the identifier '$contentTypeIdentifier' could be found.");
+            throw new RuntimeException("No ContentType with the identifier '$contentTypeIdentifier' could be found.");
         }
     }
 

--- a/src/lib/Behat/Context/ContentTypeContext.php
+++ b/src/lib/Behat/Context/ContentTypeContext.php
@@ -18,7 +18,7 @@ use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeCreateStruct;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinitionUpdateStruct;
 use Ibexa\Core\Repository\Values\User\UserReference;
-use PHPUnit\Framework\Assert as Assertion;
+use Webmozart\Assert\Assert as Assertion;
 
 final class ContentTypeContext extends RawMinkContext implements Context, SnippetAcceptingContext
 {
@@ -38,9 +38,9 @@ final class ContentTypeContext extends RawMinkContext implements Context, Snippe
     {
         try {
             $contentType = $this->contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
-            Assertion::assertEquals($id, $contentType->id);
+            Assertion::eq($contentType->id, $id);
         } catch (NotFoundException) {
-            Assertion::fail("No ContentType with the identifier '$contentTypeIdentifier' could be found.");
+            throw new \RuntimeException("No ContentType with the identifier '$contentTypeIdentifier' could be found.");
         }
     }
 

--- a/src/lib/Behat/Context/FieldTypeFormContext.php
+++ b/src/lib/Behat/Context/FieldTypeFormContext.php
@@ -14,7 +14,7 @@ use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinitionCreateStruct;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinitionUpdateStruct;
-use PHPUnit\Framework\Assert as Assertion;
+use Webmozart\Assert\Assert as Assertion;
 
 final class FieldTypeFormContext extends RawMinkContext implements SnippetAcceptingContext
 {
@@ -154,7 +154,7 @@ final class FieldTypeFormContext extends RawMinkContext implements SnippetAccept
         }
 
         foreach ($table->getColumnsHash() as $expectedField) {
-            Assertion::assertContains($expectedField, $actualInputFields);
+            Assertion::inArray($expectedField, $actualInputFields);
         }
     }
 
@@ -184,7 +184,7 @@ final class FieldTypeFormContext extends RawMinkContext implements SnippetAccept
             )
         );
 
-        Assertion::assertNotEmpty($inputNodeElements, 'The input field is not marked as required');
+        Assertion::notEmpty($inputNodeElements, 'The input field is not marked as required');
 
         $exceptions = $this->getRequiredFieldTypeExceptions($fieldTypeIdentifier);
 
@@ -194,9 +194,9 @@ final class FieldTypeFormContext extends RawMinkContext implements SnippetAccept
 
             $expectedState = array_key_exists($label, $exceptions) ? $exceptions[$label] : true;
 
-            Assertion::assertEquals(
-                $expectedState,
+            Assertion::eq(
                 $inputNodeElement->hasAttribute('required'),
+                $expectedState,
                 sprintf(
                     '%s input with id %s is not flagged as required',
                     $inputNodeElement->getAttribute('type'),

--- a/src/lib/Behat/Context/PagelayoutContext.php
+++ b/src/lib/Behat/Context/PagelayoutContext.php
@@ -12,7 +12,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
-use PHPUnit\Framework\Assert as Assertion;
+use Webmozart\Assert\Assert as Assertion;
 
 final class PagelayoutContext extends RawMinkContext implements Context, SnippetAcceptingContext
 {
@@ -29,7 +29,7 @@ final class PagelayoutContext extends RawMinkContext implements Context, Snippet
      */
     public function aPagelayoutIsConfigured(): void
     {
-        Assertion::assertTrue($this->configResolver->hasParameter('page_layout'));
+        Assertion::true($this->configResolver->hasParameter('page_layout'));
     }
 
     /**
@@ -40,7 +40,7 @@ final class PagelayoutContext extends RawMinkContext implements Context, Snippet
         $pageLayout = $this->getPageLayout();
 
         $searchedPattern = sprintf(self::TWIG_DEBUG_STOP_REGEX, preg_quote($pageLayout, null));
-        Assertion::assertMatchesRegularExpression($searchedPattern, $this->getSession()->getPage()->getOuterHtml());
+        Assertion::regex($this->getSession()->getPage()->getOuterHtml(), $searchedPattern);
     }
 
     public function getPageLayout(): string

--- a/src/lib/Behat/Context/SelectionFieldTypeFormContext.php
+++ b/src/lib/Behat/Context/SelectionFieldTypeFormContext.php
@@ -11,7 +11,7 @@ namespace Ibexa\ContentForms\Behat\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
-use PHPUnit\Framework\Assert as Assertion;
+use Webmozart\Assert\Assert as Assertion;
 
 final class SelectionFieldTypeFormContext extends RawMinkContext implements SnippetAcceptingContext
 {
@@ -68,11 +68,11 @@ final class SelectionFieldTypeFormContext extends RawMinkContext implements Snip
                 self::$fieldIdentifier
             )
         );
-        Assertion::assertNotEmpty($nodeElements, 'The select field is not marked as required');
+        Assertion::notEmpty($nodeElements, 'The select field is not marked as required');
         foreach ($nodeElements as $nodeElement) {
-            Assertion::assertEquals(
-                'required',
+            Assertion::eq(
                 $nodeElement->getAttribute('required'),
+                'required',
                 sprintf(
                     'The select with ID %s is not flagged as required',
                     $nodeElement->getAttribute('id')

--- a/src/lib/Behat/Context/UserRegistrationContext.php
+++ b/src/lib/Behat/Context/UserRegistrationContext.php
@@ -23,9 +23,9 @@ use Ibexa\Contracts\Core\Repository\Values\User\User;
 use Ibexa\Contracts\Core\Repository\Values\User\UserGroup;
 use Ibexa\Core\Repository\Values\User\RoleCreateStruct;
 use Ibexa\Core\Repository\Values\User\UserReference;
-use PHPUnit\Framework\Assert as Assertion;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Yaml;
+use Webmozart\Assert\Assert as Assertion;
 
 final class UserRegistrationContext extends RawMinkContext implements Context, SnippetAcceptingContext
 {
@@ -295,9 +295,9 @@ final class UserRegistrationContext extends RawMinkContext implements Context, S
         $user = $this->userService->loadUserByLogin($this->registrationUsername);
         $userGroups = $this->userService->loadUserGroupsOfUser($user);
 
-        Assertion::assertEquals(
-            $userGroupName,
-            $userGroups[0]->getName()
+        Assertion::eq(
+            $userGroups[0]->getName(),
+            $userGroupName
         );
     }
 
@@ -343,7 +343,7 @@ final class UserRegistrationContext extends RawMinkContext implements Context, S
             $found = preg_match($searchedPattern, $html) === 1;
         }
 
-        Assertion::assertTrue(
+        Assertion::true(
             $found,
             "Couldn't find $template " .
             (isset($alternativeTemplate) ? "nor $alternativeTemplate " : ' ') .


### PR DESCRIPTION
> [!CAUTION]
> - [x] Remove tmp commits before merging 

:ticket: Issue | [IBX-11766](https://ibexa.atlassian.net/browse/IBX-11766) |
|----------------|-----------|

#### Related PRs: 
https://github.com/ibexa/behat/pull/184

#### Description:
Installed `webmozart/assert` library as require-dev dependency. It's still a bit "hidden" dependency (because behat package use assertions from /src directory), but at least it's defined in this specific library. Previously, phpunit was installed by indirect dependency from `ibexa/behat` package.

Replaced phpunit assertions with these from webmozart library.

#### For QA:
#### Documentation:

[IBX-11766]: https://ibexa.atlassian.net/browse/IBX-11766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ